### PR TITLE
Genbank download escapes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 * Added --rerender option to draw (new) graphics from old output, without recalculation
 * Corrected matplotlib row dendrogram orientation
 * Seaborn output no longer dumps core on large (ca. 500 genome) datasets
+* `genbank_get_genomes_by_taxon.py` attempts to identify cause for failed downloads and correct, where nomenclature/versions are at fault
 
 ## v0.2.0
 

--- a/genbank_get_genomes_by_taxon.py
+++ b/genbank_get_genomes_by_taxon.py
@@ -461,6 +461,19 @@ def write_contigs(asm_uid, contig_uids):
     logger.info("Wrote %d contigs to %s" % (retval, outfilename))
 
 
+# Function to report whether an accession has been downloaded
+def logreport_downloaded(accession, skippedlist, accessiondict, uidaccdict):
+    """Reports to logger whether alternative assemblies for an accession that
+    was missing have been downloaded
+    """
+    for vid in accessiondict[accession.split('.')[0]]:
+        if vid in skippedlist:
+            status = "NOT DOWNLOADED"
+        else:
+            status = "DOWNLOADED"
+        logger.warning("\t\t%s: %s - %s" % (vid, uidaccdict[vid],
+                                            status))
+
 # Run as script
 if __name__ == '__main__':
 
@@ -566,45 +579,31 @@ if __name__ == '__main__':
             # Has another version of this genome been successfully dl'ed
             logger.warning("\tAccession %s has versions:" %
                            acc.split('.')[0])
-            for vid in accessiondict[acc.split('.')[0]]:
-                if vid in skippedlist:
-                    status = "NOT DOWNLOADED"
-                else:
-                    status = "DOWNLOADED"
-                logger.warning("\t\t%s: %s - %s" % (vid, uidaccdict[vid],
-                                                    status))
-            url = "http://www.ncbi.nlm.nih.gov/assembly/%s" % vid
+            logreport_downloaded(acc, skippedlist, accessiondict, uidaccdict)
+            url = "http://www.ncbi.nlm.nih.gov/assembly/%s" % uid
             # Is this a GenBank sequence with no RefSeq counterpart?
             # e.g. http://www.ncbi.nlm.nih.gov/assembly/196191/
             if acc.startswith('GCA'):
                 logger.warning("\tAccession is GenBank: does RefSeq exist?")
                 logger.warning("\tCheck under 'history' at %s" % url)
                 # Check for RefSeq counterparts
-                acc = re.sub('^GCA_', 'GCF_', uidaccdict[uid])
+                rsacc = re.sub('^GCA_', 'GCF_', uidaccdict[uid])
                 logger.warning("\tAlternative RefSeq candidate accession: %s" %
-                               acc.split('.')[0])
-                for vid in accessiondict[acc.split('.')[0]]:
-                    if vid in skippedlist:
-                        status = "NOT DOWNLOADED"
-                    else:
-                        status = "DOWNLOADED"
-                    logger.warning("\t\t%s: %s - %s" % (vid, uidaccdict[vid],
-                                                        status))
+                               rsacc.split('.')[0])
+                logger.warning("\tWere alternative assemblies downloaded?")
+                logreport_downloaded(rsacc, skippedlist,
+                                     accessiondict, uidaccdict)
+            # Is this a suppressed RefSeq sequence?
             if acc.startswith('GCF'):
                 logger.warning("\tAccession is RefSeq: is it suppressed?")
                 logger.warning("\tCheck under 'history' at %s" % url)
                 # Check for GenBank counterparts
-                # Check for RefSeq counterparts
-                acc = re.sub('^GCF_', 'GCA_', uidaccdict[uid])
+                gbacc = re.sub('^GCF_', 'GCA_', uidaccdict[uid])
                 logger.warning("\tAlternative GenBank candidate accession: %s" %
-                               acc.split('.')[0])
-                for vid in accessiondict[acc.split('.')[0]]:
-                    if vid in skippedlist:
-                        status = "NOT DOWNLOADED"
-                    else:
-                        status = "DOWNLOADED"
-                    logger.warning("\t\t%s: %s - %s" % (vid, uidaccdict[vid],
-                                                        status))                
+                               gbacc.split('.')[0])
+                logger.warning("\tWere alternative assemblies downloaded?")
+                logreport_downloaded(gbacc, skippedlist,
+                                     accessiondict, uidaccdict)
     logger.info("Skipped assembly UIDs: %s" % skippedlist)
 
     # Let the user know we're done


### PR DESCRIPTION
Updates the escaping of genome names for downloaded files (converting commas to underscores; NCBI don't use percent escapes for URLs for their FTP downloads), and adds code to try to correct for download errors due to RefSeq sequence suppression, or removed GenBank files. Where correction is not possible, the output log tries to be verbose and helpful.