### PR TITLE
enable graceful replacement of classes for input not in classes.txt

### DIFF
--- a/average_nucleotide_identity.py
+++ b/average_nucleotide_identity.py
@@ -579,15 +579,21 @@ def get_labels(filename):
 
     Input files should be formatted as <key>\t<label>, one pair per line.
     """
-    try:
-        labeldict = {}
-        with open(filename, 'rU') as fh:
-            for line in fh.readlines():
+    labeldict = {}
+    with open(filename, 'rU') as fh:
+        count = 0
+        for line in fh.readlines():
+            count += 1
+            try:
                 key, label = line.strip().split('\t')
+            except ValueError:
+                logger.warning("Problem with class file: %s" % filename)
+                logger.warning("%d: %s" % (count, line.strip()))
+                logger.warning("(skipping line)")
+                continue
+            else:
                 labeldict[key] = label
-        return labeldict
-    except:
-        None
+    return labeldict
                
 
 # Write ANIb/ANIm/TETRA output

--- a/genbank_get_genomes_by_taxon.py
+++ b/genbank_get_genomes_by_taxon.py
@@ -549,10 +549,10 @@ if __name__ == '__main__':
     labelfilename = os.path.join(args.outdirname, 'labels.txt')
     logger.info("Writing classes file to %s" % classfilename)
     with open(classfilename, 'w') as fh:
-        fh.write('\n'.join(classes))
+        fh.write('\n'.join(classes) + '\n')
     logger.info("Writing labels file to %s" % labelfilename)
     with open(labelfilename, 'w') as fh:
-        fh.write('\n'.join(labels))
+        fh.write('\n'.join(labels) + '\n')
 
     # How many downloads did we do/have to skip?
     logger.info("Obtained %d assemblies" % len(contig_dict))

--- a/pyani/pyani_graphics.py
+++ b/pyani/pyani_graphics.py
@@ -274,13 +274,30 @@ def heatmap_mpl(df, outfilename=None, title=None, cmap=None,
 
     # Are there class colourbars to add?
     if classes is not None:
+        # If not all dendrogram leaves are present, extend classes
+        for name in df.index[coldend['leaves']]:
+            if name not in classes:
+                classes[name] = name
+
+        # Assign a numerical value to each class, for mpl
         classdict = {cls: idx for (idx, cls) in enumerate(classes.values())}
         # Column colourbar
-        col_cb = pd.Series([classdict[classes[name]] for name in
-                            df.index[coldend['leaves']]])
+        col_cblist = []
+        for name in df.index[coldend['leaves']]:
+            try:
+                col_cblist.append(classdict[classes[name]])
+            except KeyError:
+                col_cblist.append(classdict[name])
+        col_cb = pd.Series(col_cblist)
+
         # Row colourbar
-        row_cb = pd.Series([classdict[classes[name]] for name in
-                            df.index[rowdend['leaves']]])
+        row_cblist = []
+        for name in df.index[rowdend['leaves']]:
+            try:
+                row_cblist.append(classdict[classes[name]])
+            except KeyError:
+                row_cblist.append(classdict[name])
+        row_cb = pd.Series(row_cblist)
 
         # Create column colourbar axis
         col_cbaxes = fig.add_subplot(colGS[1, 0])


### PR DESCRIPTION
These changes implement a more graceful handling of errors/
omissions in the classes.txt file. Individual input sequences that
are not in the classes.txt file are now treated as single classes
for the colour bars. Also, the average_nucleotide_identity.py
script now warns if there are misformatted lines in classes.txt