### PR TITLE
make tests of binary dependencies work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - export PATH=$HOME/MUMmer3.23:$PATH
   - cd $HOME
   - wget ftp://ftp.ncbi.nlm.nih.gov/blast/executables/legacy/2.2.26/blast-2.2.26-x64-linux.tar.gz
-  - export PATH=blast-2.2.26/bin:$PATH
+  - export PATH=$HOME/blast-2.2.26/bin:$PATH
   - cd $TRAVIS_BUILD_DIR
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 
 # command to run tests
 script:
-  - nosetests -v --with-coverage --cover-erase --cover-package=pyani --cover-html --nocapture
+  - nosetests -v --with-coverage --cover-erase --cover-package=pyani --cover-html --nocapture tests/test_dependencies.py
 
 # application dependencies: BLAST, BLASTALL, MUMMER
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_install:
   - export PATH=$HOME/MUMmer3.23:$PATH
   - cd $HOME
   - wget ftp://ftp.ncbi.nlm.nih.gov/blast/executables/legacy/2.2.26/blast-2.2.26-x64-linux.tar.gz
+  - tar -zxvf blast-2.2.26-x64-linux.tar.gz
   - export PATH=$HOME/blast-2.2.26/bin:$PATH
   - cd $TRAVIS_BUILD_DIR
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ sudo: false
 addons:
   apt:
     packages:
+    - csh
     - ncbi-blast+
     - mummer
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 # command to run tests
 # Use --nocapture with nosetests to get extra verbose output for debugging on Travis
 script:
-  - nosetests -v --with-coverage --cover-package=pyani tests/test_concordance.py
+  - nosetests -v --with-coverage --cover-package=pyani
 
 # application dependencies: BLAST+, legacy BLAST, MUMMER
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 
 # command to run tests
 script:
-  - nosetests -v --with-coverage
+  - nosetests -v --with-coverage --nocapture
 
 # application dependencies: BLAST, BLASTALL, MUMMER
 #before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,9 @@ install:
   - "pip install codecov"
 
 # command to run tests
+# Use --nocapture with nosetests to get extra verbose output for debugging on Travis
 script:
-  - nosetests -v --with-coverage --cover-package=pyani --nocapture tests/test_concordance.py
+  - nosetests -v --with-coverage --cover-package=pyani tests/test_concordance.py
 
 # application dependencies: BLAST+, legacy BLAST, MUMMER
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,20 +12,19 @@ install:
 
 # command to run tests
 script:
-  - nosetests -v --with-coverage --nocapture
+  - nosetests -v --with-coverage --cover-erase --cover-package=pyani --cover-html --nocapture
 
 # application dependencies: BLAST, BLASTALL, MUMMER
 before_install:
   - cd $HOME
   - mkdir bin
-  - export PATH=$HOME/bin:$PATH
   - cd bin
   - wget http://downloads.sourceforge.net/project/mummer/mummer/3.23/MUMmer3.23.tar.gz
   - tar -zxf MUMmer3.23.tar.gz
   - cd MUMmer3.23
   - make
   - cd ..
-  - for x in `find MUMmer3.23/ -maxdepth 1 -executable -type f`; do cp -s $x . ; done
+  - export PATH=$HOME/bin/MUMmer3.23:$PATH
   - cd $TRAVIS_BUILD_DIR
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 # command to run tests
 # Use --nocapture with nosetests to get extra verbose output for debugging on Travis
 script:
-  - nosetests -v --with-coverage --cover-package=pyani
+  - nosetests -v --with-coverage --cover-package=pyani tests/test_concordance.py
 
 # application dependencies: BLAST+, legacy BLAST, MUMMER
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,19 @@ script:
   - nosetests -v --with-coverage --nocapture
 
 # application dependencies: BLAST, BLASTALL, MUMMER
-#before_install:
-#  - sudo apt-get -qq update
-#  - sudo apt-get install -y ncbi-blast+
-#  - sudo apt-get install -y blastall
-#  - sudo apt-get install -y mummer
+before_install:
+  - cd $HOME
+  - mkdir bin
+  - export PATH=$HOME/bin:$PATH
+  - cd bin
+  - wget http://downloads.sourceforge.net/project/mummer/mummer/3.23/MUMmer3.23.tar.gz
+  - tar -zxf MUMmer3.23.tar.gz
+  - cd MUMmer3.23
+  - make
+  - cd ..
+  - for x in `find MUMmer3.23/ -maxdepth 1 -executable -type f`; do cp -s $x . ; done
+  - cd $TRAVIS_BUILD_DIR
+
 sudo: false
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 
 # command to run tests
 script:
-  - nosetests -v --with-coverage --cover-erase --cover-package=pyani --cover-html --nocapture tests/test_dependencies.py
+  - nosetests -v --with-coverage --cover-erase --cover-package=pyani --cover-html --nocapture tests/test_concordance.py
 
 # application dependencies: BLAST, BLASTALL, MUMMER
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,17 +14,18 @@ install:
 script:
   - nosetests -v --with-coverage --cover-erase --cover-package=pyani --cover-html --nocapture tests/test_concordance.py
 
-# application dependencies: BLAST, BLASTALL, MUMMER
+# application dependencies: BLAST+, legacy BLAST, MUMMER
 before_install:
   - cd $HOME
-  - mkdir bin
-  - cd bin
   - wget http://downloads.sourceforge.net/project/mummer/mummer/3.23/MUMmer3.23.tar.gz
   - tar -zxf MUMmer3.23.tar.gz
   - cd MUMmer3.23
   - make
   - cd ..
-  - export PATH=$HOME/bin/MUMmer3.23:$PATH
+  - export PATH=$HOME/MUMmer3.23:$PATH
+  - cd $HOME
+  - wget ftp://ftp.ncbi.nlm.nih.gov/blast/executables/legacy/2.2.26/blast-2.2.26-x64-linux.tar.gz
+  - export PATH=blast-2.2.26/bin:$PATH
   - cd $TRAVIS_BUILD_DIR
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 
 # command to run tests
 script:
-  - nosetests -v --with-coverage --cover-erase --cover-package=pyani --cover-html --nocapture tests/test_concordance.py
+  - nosetests -v --with-coverage --cover-package=pyani --nocapture tests/test_concordance.py
 
 # application dependencies: BLAST+, legacy BLAST, MUMMER
 before_install:

--- a/pyani/anib.py
+++ b/pyani/anib.py
@@ -133,16 +133,15 @@ def get_fragment_lengths(fastafile):
 
 # Make a dependency graph of BLAST commands
 def make_job_graph(infiles, fragfiles, outdir,
-                   format_exe=pyani_config.MAKEBLASTDB_DEFAULT,
-                   blast_exe=pyani_config.BLASTN_DEFAULT,
+                   format_exe=None, blast_exe=None,
                    mode="ANIb", jobprefix="ANIBLAST"):
     """Return a job dependency graph, based on the passed input sequence files.
 
     - infiles - a list of paths to input FASTA files
     - fragfiles - a list of paths to fragmented input FASTA files
     - outdir - path to output directory
-    - blastdb_exe - path to the database formatting executable
-    - blastn_exe - path to BLASTN executable
+    - format_exe - path to the database formatting executable
+    - blast_exe - path to BLASTN executable
     - mode - which BLAST mode are we running in: ANIb or ANIblastall
 
     By default, will run ANIb - it *is* possible to make a mess of passing the
@@ -160,9 +159,17 @@ def make_job_graph(infiles, fragfiles, outdir,
     if mode == "ANIb":  # BLAST/formatting executable depends on mode
         construct_db_cmdline = construct_makeblastdb_cmd
         construct_blast_cmdline = construct_blastn_cmdline
+        if format_exe is None:
+            format_exe = pyani_config.MAKEBLASTDB_DEFAULT
+        if blast_exe is None:
+            blast_exe = pyani_config.BLASTN_DEFAULT
     else:
         construct_db_cmdline = construct_formatdb_cmd
         construct_blast_cmdline = construct_blastall_cmdline
+        if format_exe is None:
+            format_exe = pyani_config.FORMATDB_DEFAULT
+        if blast_exe is None:
+            blast_exe = pyani_config.BLASTALL_DEFAULT
 
     # Create dictionary of database building jobs, keyed by db name
     for idx, fname in enumerate(infiles):

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -231,6 +231,8 @@ def test_anim_concordance():
     print(parts[-1])
     print(os.path.isfile(parts[-1]))
     multiprocessing_run(cmdlist, verbose=False)
+    print(outdirname)
+    print(os.listdir(outdirname))
     # Process .delta files
     anim_data = anim.process_deltadir(outdirname, org_lengths)
     anim_pid = anim_data[1].sort_index(axis=0).sort_index(axis=1) * 100.

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -227,9 +227,9 @@ def test_anim_concordance():
     cmd = cmdlist[0]
     parts = cmdlist.split()
     print(parts[-2])
-    print(os.path.isfile(parts[-2]))
+#    print(os.path.isfile(parts[-2]))
     print(parts[-1])
-    print(os.path.isfile(parts[-1]))
+#    print(os.path.isfile(parts[-1]))
     multiprocessing_run(cmdlist, verbose=False)
     # Process .delta files
     anim_data = anim.process_deltadir(outdirname, org_lengths)

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -224,6 +224,10 @@ def test_anim_concordance():
     cmdlist = anim.generate_nucmer_commands(infiles, outdirname,
                                             pyani_config.NUCMER_DEFAULT)
     print('\n'.join(cmdlist))
+    cmd = cmdlist[0]
+    parts = cmdlist.split()
+    print(parts[-2], os.path.isfile(parts[-2]))
+    print(parts[-1], os.path.isfile(parts[-1]))
     multiprocessing_run(cmdlist, verbose=False)
     # Process .delta files
     anim_data = anim.process_deltadir(outdirname, org_lengths)

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -227,9 +227,9 @@ def test_anim_concordance():
     cmd = cmdlist[0]
     parts = cmd.split()
     print(parts[-2])
-#    print(os.path.isfile(parts[-2]))
+    print(os.path.isfile(parts[-2]))
     print(parts[-1])
-#    print(os.path.isfile(parts[-1]))
+    print(os.path.isfile(parts[-1]))
     multiprocessing_run(cmdlist, verbose=False)
     # Process .delta files
     anim_data = anim.process_deltadir(outdirname, org_lengths)

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -176,6 +176,7 @@ def test_aniblastall_concordance():
     jobgraph = anib.make_job_graph(infiles, fragfiles, outdirname,
                                    mode="ANIblastall")
     print("\nJobgraph:\n", jobgraph)
+    print("\nJob 0:\n", jobgraph[0].script)
 
     # Run jobgraph with multiprocessing
     run_dependency_graph(jobgraph)

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -154,6 +154,7 @@ def test_anib_concordance():
 
 
 # Test concordance of this code with JSpecies output
+@nottest
 def test_aniblastall_concordance():
     """Test concordance of ANIblastall method with JSpecies output."""
     # Make/check output directory
@@ -281,7 +282,6 @@ def test_anim_concordance():
 
 
 # Test concordance of this code with JSpecies output
-@nottest
 def test_tetra_concordance():
     """Test concordance of TETRA method with JSpecies output."""
     # Make/check output directory

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -206,6 +206,7 @@ def test_aniblastall_concordance():
 
 
 # Test concordance of this code with JSpecies output
+@nottest
 def test_anim_concordance():
     """Test concordance of ANIm method with JSpecies output."""
     # Make/check output directory
@@ -255,6 +256,7 @@ def test_anim_concordance():
 
 
 # Test concordance of this code with JSpecies output
+@nottest
 def test_tetra_concordance():
     """Test concordance of TETRA method with JSpecies output."""
     # Make/check output directory

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -177,9 +177,14 @@ def test_aniblastall_concordance():
                                    mode="ANIblastall")
     print("\nJobgraph:\n", jobgraph)
     print("\nJob 0:\n", jobgraph[0].script)
+    subprocess.run(jobgraph[0].script, shell=sys.platform != "win32",
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE)
+    print(result.stdout)
+    print(result.stderr)
 
     # Run jobgraph with multiprocessing
-    run_dependency_graph(jobgraph)
+    #run_dependency_graph(jobgraph)
     print("Ran multiprocessing jobs")
 
     # Process BLAST; the pid data is in anib_data[1]

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -226,8 +226,10 @@ def test_anim_concordance():
     print('\n'.join(cmdlist))
     cmd = cmdlist[0]
     parts = cmdlist.split()
-    print(parts[-2], os.path.isfile(parts[-2]))
-    print(parts[-1], os.path.isfile(parts[-1]))
+    print(parts[-2])
+    print(os.path.isfile(parts[-2]))
+    print(parts[-1])
+    print(os.path.isfile(parts[-1]))
     multiprocessing_run(cmdlist, verbose=False)
     # Process .delta files
     anim_data = anim.process_deltadir(outdirname, org_lengths)

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -93,7 +93,6 @@ def delete_and_remake_outdir(mode):
 
 
 # Test concordance of this code with JSpecies output
-@nottest
 def test_anib_concordance():
     """Test concordance of ANIb method with JSpecies output.
 
@@ -145,7 +144,9 @@ def test_anib_concordance():
                                   'ANIb_diff.tab'),
                      sep='\t')
     print("ANIb concordance test output placed in %s" % outdirname)
-    print(anib_pid, anib_jspecies, anib_diff)
+    print("ANIb PID: \n", anib_pid)
+    print("ANIb JSpecies: \n", anib_jspecies)
+    print("ANIb diff: \n", anib_diff)
 
     # We'd like the absolute difference reported to be < ANIB_THRESHOLD
     max_diff = anib_diff.abs().values.max()
@@ -154,7 +155,6 @@ def test_anib_concordance():
 
 
 # Test concordance of this code with JSpecies output
-@nottest
 def test_aniblastall_concordance():
     """Test concordance of ANIblastall method with JSpecies output."""
     # Make/check output directory
@@ -178,12 +178,6 @@ def test_aniblastall_concordance():
                                    mode="ANIblastall")
     print("\nJobgraph:\n", jobgraph)
     print("\nJob 0:\n", jobgraph[0].script)
-    #result = subprocess.run(jobgraph[0].script,
-    #                        shell=sys.platform != "win32",
-    #                        stdout=subprocess.PIPE,
-    #                        stderr=subprocess.PIPE)
-    #print(result.stdout)
-    #print(result.stderr)
 
     # Run jobgraph with multiprocessing
     run_dependency_graph(jobgraph)
@@ -211,7 +205,9 @@ def test_aniblastall_concordance():
                                   'ANIblastall_diff.tab'),
                      sep='\t')
     print("ANIblastall concordance test output placed in %s" % outdirname)
-    print(aniblastall_pid, aniblastall_jspecies, aniblastall_diff)
+    print("ANIblastall PID:\n", aniblastall_pid)
+    print("ANIblastall JSpecies:\n", aniblastall_jspecies)
+    print("ANIblastall diff:\n", aniblastall_diff)
 
     # We'd like the absolute difference reported to be < ANIBLASTALL_THRESHOLD
     max_diff = aniblastall_diff.abs().values.max()
@@ -220,7 +216,6 @@ def test_aniblastall_concordance():
 
 
 # Test concordance of this code with JSpecies output
-@nottest
 def test_anim_concordance():
     """Test concordance of ANIm method with JSpecies output."""
     # Make/check output directory
@@ -241,15 +236,8 @@ def test_anim_concordance():
     cmdlist = anim.generate_nucmer_commands(infiles, outdirname,
                                             pyani_config.NUCMER_DEFAULT)
     print('\n'.join(cmdlist))
-    cmd = cmdlist[0]
     parts = cmd.split()
-    print(parts[-2])
-    print(os.path.isfile(parts[-2]))
-    print(parts[-1])
-    print(os.path.isfile(parts[-1]))
     multiprocessing_run(cmdlist, verbose=False)
-    print(outdirname)
-    print(os.listdir(outdirname))
     # Process .delta files
     anim_data = anim.process_deltadir(nucmername, org_lengths)
     anim_pid = anim_data[1].sort_index(axis=0).sort_index(axis=1) * 100.
@@ -317,7 +305,9 @@ def test_tetra_concordance():
                                    'tetra_diff.tab'),
                       sep='\t')
     print("TETRA concordance test output placed in %s" % outdirname)
-    print(tetra_correlations, tetra_jspecies, tetra_diff)
+    print("TETRA correlations:\n", tetra_correlations)
+    print("TETRA JSpecies:\n", tetra_jspecies)
+    print("TETRA diff:\n", tetra_diff)
 
     # We'd like the absolute difference reported to be < TETRA_THRESHOLD
     max_diff = tetra_diff.abs().values.max()

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -206,7 +206,6 @@ def test_aniblastall_concordance():
 
 
 # Test concordance of this code with JSpecies output
-@nottest
 def test_anim_concordance():
     """Test concordance of ANIm method with JSpecies output."""
     # Make/check output directory
@@ -231,7 +230,13 @@ def test_anim_concordance():
     print(os.path.isfile(parts[-2]))
     print(parts[-1])
     print(os.path.isfile(parts[-1]))
-    multiprocessing_run(cmdlist, verbose=False)
+    #multiprocessing_run(cmdlist, verbose=False)
+    result = subprocess.run(cmd, shell=sys.platform != "win32",
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            check=True)
+    print(result.stdout)
+    print(result.stderr)
     print(outdirname)
     print(os.listdir(outdirname))
     # Process .delta files

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -93,6 +93,7 @@ def delete_and_remake_outdir(mode):
 
 
 # Test concordance of this code with JSpecies output
+@nottest
 def test_anib_concordance():
     """Test concordance of ANIb method with JSpecies output.
 
@@ -153,7 +154,6 @@ def test_anib_concordance():
 
 
 # Test concordance of this code with JSpecies output
-@nottest
 def test_aniblastall_concordance():
     """Test concordance of ANIblastall method with JSpecies output."""
     # Make/check output directory
@@ -171,16 +171,16 @@ def test_aniblastall_concordance():
     # Make fragments
     fragfiles, fraglengths = anib.fragment_FASTA_files(infiles, outdirname,
                                                        pyani_config.FRAGSIZE)
-    # Build databases
-    cmdlist = anib.generate_blastdb_commands(infiles, outdirname,
-                                             pyani_config.FORMATDB_DEFAULT,
-                                             mode="ANIblastall")
-    multiprocessing_run(cmdlist)
-    # Run pairwise BLASTN
-    cmdlist = anib.generate_blastn_commands(fragfiles, outdirname,
-                                            pyani_config.BLASTALL_DEFAULT,
-                                            mode="ANIblastall")
-    multiprocessing_run(cmdlist, verbose=False)
+
+    # Build jobgraph
+    jobgraph = anib.make_job_graph(infiles, fragfiles, outdirname,
+                                   mode="ANIblastall")
+    print("\nJobgraph:\n", jobgraph)
+
+    # Run jobgraph with multiprocessing
+    run_dependency_graph(jobgraph)
+    print("Ran multiprocessing jobs")
+
     # Process BLAST; the pid data is in anib_data[1]
     aniblastall_data = anib.process_blast(outdirname, org_lengths,
                                           fraglengths,

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -225,7 +225,7 @@ def test_anim_concordance():
                                             pyani_config.NUCMER_DEFAULT)
     print('\n'.join(cmdlist))
     cmd = cmdlist[0]
-    parts = cmdlist.split()
+    parts = cmd.split()
     print(parts[-2])
 #    print(os.path.isfile(parts[-2]))
     print(parts[-1])

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -94,7 +94,6 @@ def delete_and_remake_outdir(mode):
 
 
 # Test concordance of ANIb with JSpecies output
-@nottest
 def test_anib_concordance():
     """Test concordance of ANIb method with JSpecies output.
 
@@ -157,7 +156,6 @@ def test_anib_concordance():
 
 
 # Test concordance of ANIblastall with JSpecies output
-@nottest
 def test_aniblastall_concordance():
     """Test concordance of ANIblastall method with JSpecies output."""
     # Make/check output directory
@@ -272,7 +270,6 @@ def test_anim_concordance():
 
 
 # Test concordance of TETRA code with JSpecies output
-@nottest
 def test_tetra_concordance():
     """Test concordance of TETRA method with JSpecies output."""
     # Make/check output directory

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -177,7 +177,8 @@ def test_aniblastall_concordance():
                                    mode="ANIblastall")
     print("\nJobgraph:\n", jobgraph)
     print("\nJob 0:\n", jobgraph[0].script)
-    subprocess.run(jobgraph[0].script, shell=sys.platform != "win32",
+    result = subprocess.run(jobgraph[0].script,
+                            shell=sys.platform != "win32",
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE)
     print(result.stdout)

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -206,7 +206,6 @@ def test_aniblastall_concordance():
 
 
 # Test concordance of this code with JSpecies output
-@nottest
 def test_anim_concordance():
     """Test concordance of ANIm method with JSpecies output."""
     # Make/check output directory

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -236,7 +236,6 @@ def test_anim_concordance():
     cmdlist = anim.generate_nucmer_commands(infiles, outdirname,
                                             pyani_config.NUCMER_DEFAULT)
     print('\n'.join(cmdlist))
-    parts = cmd.split()
     multiprocessing_run(cmdlist, verbose=False)
     # Process .delta files
     anim_data = anim.process_deltadir(nucmername, org_lengths)

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -9,7 +9,8 @@ If the test is run directly at the command-line, the output obtained by each
 test is returned to STDOUT.
 """
 from nose.tools import assert_equal, assert_less, nottest
-from pyani.run_multiprocessing import run_dependency_graph
+from pyani.run_multiprocessing import run_dependency_graph, \
+    multiprocessing_run
 
 import os
 import pandas as pd
@@ -92,7 +93,8 @@ def delete_and_remake_outdir(mode):
     return outdirname
 
 
-# Test concordance of this code with JSpecies output
+# Test concordance of ANIb with JSpecies output
+@nottest
 def test_anib_concordance():
     """Test concordance of ANIb method with JSpecies output.
 
@@ -154,7 +156,8 @@ def test_anib_concordance():
     assert_less(max_diff, ANIB_THRESHOLD)
 
 
-# Test concordance of this code with JSpecies output
+# Test concordance of ANIblastall with JSpecies output
+@nottest
 def test_aniblastall_concordance():
     """Test concordance of ANIblastall method with JSpecies output."""
     # Make/check output directory
@@ -215,7 +218,7 @@ def test_aniblastall_concordance():
     assert_less(max_diff, ANIB_THRESHOLD)
 
 
-# Test concordance of this code with JSpecies output
+# Test concordance of ANIm with JSpecies output
 def test_anim_concordance():
     """Test concordance of ANIm method with JSpecies output."""
     # Make/check output directory
@@ -268,7 +271,8 @@ def test_anim_concordance():
     assert_less(max_diff, ANIM_THRESHOLD)
 
 
-# Test concordance of this code with JSpecies output
+# Test concordance of TETRA code with JSpecies output
+@nottest
 def test_tetra_concordance():
     """Test concordance of TETRA method with JSpecies output."""
     # Make/check output directory

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -24,14 +24,14 @@ curdir = os.path.dirname(os.path.abspath(__file__))
 # Path to JSpecies output data. This data is pre-prepared. If you replace
 # the test data with your own data, you will need to replace this file,
 # or change the file path.
-JSPECIES_OUTFILE = os.path.join(curdir, 'test_JSpecies',
-                                'jspecies_results.tab')
+JSPECIES_OUTFILE = os.path.relpath(os.path.join(curdir, 'test_JSpecies',
+                                               'jspecies_results.tab'))
 
 # Path to test input data
-INDIRNAME = os.path.join(curdir, 'test_ani_data')
+INDIRNAME = os.path.relpath(os.path.join(curdir, 'test_ani_data'))
 
 # Path to directory for concordance test output
-OUTDIRNAME = os.path.join(curdir, 'test_concordance')
+OUTDIRNAME = os.path.relpath(os.path.join(curdir, 'test_concordance'))
 
 # Thresholds for allowable difference
 TETRA_THRESHOLD = 0.1
@@ -206,7 +206,6 @@ def test_aniblastall_concordance():
 
 
 # Test concordance of this code with JSpecies output
-@nottest
 def test_anim_concordance():
     """Test concordance of ANIm method with JSpecies output."""
     # Make/check output directory
@@ -224,6 +223,7 @@ def test_anim_concordance():
     # Run pairwise NUCmer
     cmdlist = anim.generate_nucmer_commands(infiles, outdirname,
                                             pyani_config.NUCMER_DEFAULT)
+    print('\n'.join(cmdlist))
     multiprocessing_run(cmdlist, verbose=False)
     # Process .delta files
     anim_data = anim.process_deltadir(outdirname, org_lengths)
@@ -297,13 +297,3 @@ def test_tetra_concordance():
     print("Maximum difference for TETRA: %e" % max_diff)
     assert_less(max_diff, TETRA_THRESHOLD)
     
-
-# Run as script
-if __name__ == '__main__':
-    import inspect
-    import test_concordance
-    functions = [o[0] for o in inspect.getmembers(test_concordance) if
-                 inspect.isfunction(o[1]) and o[0].startswith('test')]
-    for fn in functions:
-        print("\nFunction called: {}()".format(fn))
-        locals()[fn]()

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -206,6 +206,7 @@ def test_aniblastall_concordance():
 
 
 # Test concordance of this code with JSpecies output
+@nottest
 def test_anim_concordance():
     """Test concordance of ANIm method with JSpecies output."""
     # Make/check output directory

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -81,9 +81,13 @@ def parse_table(filename, title):
 
 # Make output directory if necessary
 def delete_and_remake_outdir(mode):
-    """Make concordance test output directory."""
+    """Make concordance test output directories."""
     outdirname = '_'.join([OUTDIRNAME, mode])
-    shutil.rmtree(outdirname)
+    try:
+        shutil.rmtree(outdirname, ignore_errors=True)
+    except FileNotFoundError:
+        print("Did not find %s to delete it (continuing)")
+        pass
     os.makedirs(outdirname, exist_ok=True)
     return outdirname
 

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -177,15 +177,15 @@ def test_aniblastall_concordance():
                                    mode="ANIblastall")
     print("\nJobgraph:\n", jobgraph)
     print("\nJob 0:\n", jobgraph[0].script)
-    result = subprocess.run(jobgraph[0].script,
-                            shell=sys.platform != "win32",
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
-    print(result.stdout)
-    print(result.stderr)
+    #result = subprocess.run(jobgraph[0].script,
+    #                        shell=sys.platform != "win32",
+    #                        stdout=subprocess.PIPE,
+    #                        stderr=subprocess.PIPE)
+    #print(result.stdout)
+    #print(result.stderr)
 
     # Run jobgraph with multiprocessing
-    #run_dependency_graph(jobgraph)
+    run_dependency_graph(jobgraph)
     print("Ran multiprocessing jobs")
 
     # Process BLAST; the pid data is in anib_data[1]

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -51,6 +51,18 @@ def test_run_blast():
     print(result.stdout)
     assert_equal(result.stdout[:6], b'blastn')
 
+
+def test_run_blastall():
+    """Test that legacy BLAST is runnable."""
+    cmd = "blastall"
+    # Can't use check=True, as blastall without arguments returns 1!
+    result = subprocess.run(cmd, shell=sys.platform != "win32",
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE)
+    print(result.stdout)
+    assert_equal(result.stdout[1:9], b'blastall')
+
+
 def test_run_nucmer():
     """Test that NUCmer is runnable."""
     cmd = "nucmer --version"

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -14,6 +14,8 @@ test is returned to STDOUT.
 import subprocess
 import sys
 
+from nose.tools import assert_equal
+
 def test_import_biopython():
     """Test Biopython import."""
     import Bio
@@ -42,18 +44,22 @@ def test_import_scipy():
 def test_run_blast():
     """Test that BLAST+ is runnable."""
     cmd = "blastn -version"
-    subprocess.run(cmd, shell=sys.platform != "win32",
-                   stdout=subprocess.PIPE,
-                   stderr=subprocess.PIPE,
-                   check=True)
+    result = subprocess.run(cmd, shell=sys.platform != "win32",
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            check=True)
+    print(result.stdout)
+    assert_equal(result.stdout[:6] == 'blastn')
 
 def test_run_nucmer():
     """Test that NUCmer is runnable."""
     cmd = "nucmer --version"
-    subprocess.run(cmd, shell=sys.platform != "win32",
-                   stdout=subprocess.PIPE,
-                   stderr=subprocess.PIPE,
-                   check=True)
+    result = subprocess.run(cmd, shell=sys.platform != "win32",
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            check=True)
+    print(result.stdout)
+    assert_equal(result.stdout[:6] == 'nucmer')
 
 
 # Run as script

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -49,7 +49,7 @@ def test_run_blast():
                             stderr=subprocess.PIPE,
                             check=True)
     print(result.stdout)
-    assert_equal(result.stdout[:6] == 'blastn')
+    assert_equal(result.stdout[:6], b'blastn')
 
 def test_run_nucmer():
     """Test that NUCmer is runnable."""
@@ -58,8 +58,8 @@ def test_run_nucmer():
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,
                             check=True)
-    print(result.stdout)
-    assert_equal(result.stdout[:6] == 'nucmer')
+    print(result.stderr)  # NUCmer puts output to STDERR!
+    assert_equal(result.stderr[:6], b'nucmer')
 
 
 # Run as script

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -44,14 +44,16 @@ def test_run_blast():
     cmd = "blastn -version"
     subprocess.run(cmd, shell=sys.platform != "win32",
                    stdout=subprocess.PIPE,
-                   stderr=subprocess.PIPE)
+                   stderr=subprocess.PIPE,
+                   check=True)
 
 def test_run_nucmer():
     """Test that NUCmer is runnable."""
     cmd = "nucmer --version"
     subprocess.run(cmd, shell=sys.platform != "win32",
                    stdout=subprocess.PIPE,
-                   stderr=subprocess.PIPE)
+                   stderr=subprocess.PIPE,
+                   check=True)
 
 
 # Run as script


### PR DESCRIPTION
These commits collectively modify Travis CI settings to install binary dependencies, and make the concordance tests work both locally and on Travis CI.