### PR TITLE
fix for Issue 53

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 ## v0.2.1.dev
 
 * fix to `genbank_get_genomes_by_taxon.py` to account for NCBI FTP location changes
+* fixed issue #52 (local variable bug)
+* fixed issued #49 (TETRA failure) and #51 (matplotlib bug)
 * add several tests and support for `codecov.io`, `landscape.io` and `Travis-CI`
 * removed requirement for `rpy2`
 * moved scripts to `bin/` subdirectory

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## v0.2.1.dev
 
+* fix for issue #53 (--maxmatch has no effect)
 * fix to `genbank_get_genomes_by_taxon.py` to account for NCBI FTP location changes
 * fixed issue #52 (local variable bug)
 * fixed issued #49 (TETRA failure) and #51 (matplotlib bug)

--- a/bin/average_nucleotide_identity.py
+++ b/bin/average_nucleotide_identity.py
@@ -238,9 +238,9 @@ def parse_cmdline():
     parser.add_argument("--SGEgroupsize", dest="sgegroupsize",
                         action="store", default=10000, type=int,
                         help="Number of jobs to place in an SGE array group")
-    #parser.add_argument("--maxmatch", dest="maxmatch",
-    #                    action="store_true", default=False,
-    #                    help="Override MUMmer to allow all NUCmer matches")
+    parser.add_argument("--maxmatch", dest="maxmatch",
+                        action="store_true", default=False,
+                        help="Override MUMmer to allow all NUCmer matches")
     parser.add_argument("--nucmer_exe", dest="nucmer_exe",
                         action="store", default=pyani_config.NUCMER_DEFAULT,
                         help="Path to NUCmer executable")
@@ -374,6 +374,7 @@ def calculate_anim(infiles, org_lengths):
     if not args.skip_nucmer:
         joblist = anim.generate_nucmer_jobs(infiles, args.outdirname,
                                             nucmer_exe=args.nucmer_exe,
+                                            maxmatch=args.maxmatch,
                                             jobprefix=args.jobprefix)
         if args.scheduler == 'multiprocessing':
             logger.info("Running jobs with multiprocessing")

--- a/pyani/anim.py
+++ b/pyani/anim.py
@@ -32,6 +32,7 @@ from .pyani_tools import ANIResults
 # Generate list of Job objects, one per NUCmer run
 def generate_nucmer_jobs(filenames, outdir='.',
                          nucmer_exe=pyani_config.NUCMER_DEFAULT,
+                         maxmatch=False,
                          jobprefix="ANINUCmer"):
     """Return a list of Jobs describing NUCmer command-lines for ANIm
 
@@ -43,7 +44,8 @@ def generate_nucmer_jobs(filenames, outdir='.',
     Loop over all FASTA files, generating Jobs describing NUCmer command lines
     for each pairwise comparison.
     """
-    cmdlines = generate_nucmer_commands(filenames, outdir, nucmer_exe)
+    cmdlines = generate_nucmer_commands(filenames, outdir, nucmer_exe,
+                                        maxmatch)
     joblist = []
     for idx, cmd in enumerate(cmdlines):
         joblist.append(pyani_jobs.Job("%s_%06d" % (jobprefix, idx), cmd))
@@ -53,7 +55,8 @@ def generate_nucmer_jobs(filenames, outdir='.',
 # Generate list of NUCmer pairwise comparison command lines from
 # passed sequence filenames
 def generate_nucmer_commands(filenames, outdir='.',
-                             nucmer_exe=pyani_config.NUCMER_DEFAULT):
+                             nucmer_exe=pyani_config.NUCMER_DEFAULT,
+                             maxmatch=False):
     """Return a list of NUCmer command-lines for ANIm
 
     - filenames - a list of paths to input FASTA files
@@ -67,7 +70,7 @@ def generate_nucmer_commands(filenames, outdir='.',
     cmdlines = []
     for idx, fname1 in enumerate(filenames[:-1]):
         cmdlines.extend([construct_nucmer_cmdline(fname1, fname2, outdir,
-                                                  nucmer_exe) for
+                                                  nucmer_exe, maxmatch) for
                          fname2 in filenames[idx+1:]])
     return cmdlines
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy>=1.10.0.post2
-scipy>=0.16.0
-matplotlib>=1.4.3
-biopython>=1.65
-pandas>=0.17.0
-seaborn>=0.7.0
+numpy
+scipy
+matplotlib
+biopython
+pandas
+seaborn


### PR DESCRIPTION
`average_nucleotide_identity.py` now pays attention to the `--maxmatch` option and passes it through to the command-line constructor.