### PR TITLE
Add --version switch to average_nucleotide_identity.py

### DIFF
--- a/bin/average_nucleotide_identity.py
+++ b/bin/average_nucleotide_identity.py
@@ -178,6 +178,8 @@ from pyani import __version__ as VERSION
 def parse_cmdline():
     """Parse command-line arguments for script."""
     parser = ArgumentParser(prog="average_nucleotide_identity.py")
+    parser.add_argument('--version', action='version',
+                        version='%(prog)s using pyani ' + VERSION)
     parser.add_argument("-o", "--outdir", dest="outdirname",
                         action="store", default=None,
                         help="Output directory")

--- a/bin/average_nucleotide_identity.py
+++ b/bin/average_nucleotide_identity.py
@@ -179,7 +179,7 @@ def parse_cmdline():
     """Parse command-line arguments for script."""
     parser = ArgumentParser(prog="average_nucleotide_identity.py")
     parser.add_argument('--version', action='version',
-                        version='%(prog)s using pyani ' + VERSION)
+                        version='%(prog)s: pyani ' + VERSION)
     parser.add_argument("-o", "--outdir", dest="outdirname",
                         action="store", default=None,
                         help="Output directory")


### PR DESCRIPTION
This would partly address #65 

Code change based on https://docs.python.org/3/library/argparse.html example, gives:

```
$ average_nucleotide_identity.py --version
average_nucleotide_identity.py using pyani 0.2.3
```

I have not made a similar change to genbank_get_genomes_by_taxon.py as it does not actually use the pyani libraries.

It might be sensible to give both scripts their own version numbers separate from the pyani library version?