### PR TITLE
Change how catch FTP timeouts

### DIFF
--- a/bin/genbank_get_genomes_by_taxon.py
+++ b/bin/genbank_get_genomes_by_taxon.py
@@ -332,11 +332,20 @@ def retrieve_asm_contigs(filestem,
     # Get data info
     try:
         response = urlopen(url, timeout=args.timeout)
-    except (HTTPError, URLError):
+    except HTTPError:
         logger.error("Download failed for URL: %s\n%s",
                      url, last_exception())
         raise NCBIDownloadException()
+    except URLError as e:
+        if isinstance(e.reason, timeout):
+            logger.error("Download timed out for URL: %s\n%s",
+                         url, last_exception())
+        else:
+            logger.error("Download failed for URL: %s\n%s",
+                         url, last_exception())
+        raise NCBIDownloadException()
     except timeout:
+        # TODO: Does this ever happen?
         logger.error("Download timed out for URL: %s\n%s",
                      url, last_exception())
         raise NCBIDownloadException()


### PR DESCRIPTION
I had an exception where ``URLError`` was thrown with a reason of timeout. It seems that ``socket.timeout`` may not get used as an exception, rather as a reason?

Unfortunately on retesting the timeout seemed to go away...