### PR TITLE
Must escape hash and brackets too for NCBI FTP URL

### DIFF
--- a/bin/genbank_get_genomes_by_taxon.py
+++ b/bin/genbank_get_genomes_by_taxon.py
@@ -212,9 +212,9 @@ def extract_filestem(data):
     Some illegal characters may occur in AssemblyName - for these, a more
     robust regex replace/escape may be required. Sadly, NCBI don't just
     use standard percent escapes, but instead replace certain
-    characters with underscores.
+    characters with underscores: white space, slash, comma, hash, brackets.
     """
-    escapes = re.compile(r"[\s/,]")
+    escapes = re.compile(r"[\s/,#\(\)]")
     escname = re.sub(escapes, '_', data['AssemblyName'])
     return '_'.join([data['AssemblyAccession'], escname])
 


### PR DESCRIPTION
e.g. using txid 613 problem cases include:

ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/001/564/475/GCA_001564475.1_12082_3#81/GCA_001564475.1_12082_3#81_genomic.fna.gz
-->
ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/001/564/475/GCA_001564475.1_12082_3_81/GCA_001564475.1_12082_3_81_genomic.fna.gz

and:

ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/468/075/GCA_000468075.1_Serratia_fanticola_AU-P3(3)/GCA_000468075.1_Serratia_fanticola_AU-P3(3)_genomic.fna.gz
-->
ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/468/075/GCA_000468075.1_Serratia_fanticola_AU-P3_3_/GCA_000468075.1_Serratia_fanticola_AU-P3_3__genomic.fna.gz

With this change I went from approx 204 genomes to 410 genomes for tax id 613 (with two failures which both had status files saying they had been replaced).