### PR TITLE
Remove logging about removing dir with NOCLOBBER

### DIFF
--- a/bin/average_nucleotide_identity.py
+++ b/bin/average_nucleotide_identity.py
@@ -319,13 +319,13 @@ def make_outdir():
             logger.error("Output directory %s would overwrite existing " +
                          "files (exiting)", args.outdirname)
             sys.exit(1)
+        elif args.noclobber:
+            logger.warning("NOCLOBBER: not actually deleting directory %s",
+                           args.outdirname)
         else:
             logger.info("Removing directory %s and everything below it",
                         args.outdirname)
-            if args.noclobber:
-                logger.warning("NOCLOBBER: not actually deleting directory")
-            else:
-                shutil.rmtree(args.outdirname)
+            shutil.rmtree(args.outdirname)
     logger.info("Creating directory %s", args.outdirname)
     try:
         os.makedirs(args.outdirname)   # We make the directory recursively


### PR DESCRIPTION
Currently get:

```
INFO: command-line: ...
INFO: Input directory: interesting_serratia
INFO: Removing directory interesting_serratia_cmp and everything below it
WARNING: NOCLOBBER: not actually deleting directory
...
```

With this change get:

```
INFO: command-line: ...
INFO: Input directory: interesting_serratia
WARNING: NOCLOBBER: not actually deleting directory interesting_serratia_cmp
...
```

This removes the scary message ;)

There is scope for further simplification here when (re)creating the directories...