### PR TITLE
Explicit error if missing nucmer delta files

### DIFF
--- a/pyani/anim.py
+++ b/pyani/anim.py
@@ -195,4 +195,12 @@ def process_deltadir(delta_dir, org_lengths, logger=None):
         results.add_sim_errors(qname, sname, tot_sim_error)
         results.add_pid(qname, sname, perc_id)
         results.add_coverage(qname, sname, query_cover, sbjct_cover)
+    # Check for missing data by using fact that alignment_lengths
+    # default to NaN (other values default to zero or one):
+    missing = results.alignment_lengths.isnull().values.sum()
+    if missing:
+        logger.error("Missing %i alignment lengths. There could be "
+                     "missing delta files if using --skip_nucmer?" %
+                     missing)
+        raise RuntimeError("Missing %i alignment lengths." % missing)
     return results


### PR DESCRIPTION
See #80. With this pull request the script now logs an error, and raises a RuntimeError, rather than failing during the dendrogram drawing stage with:

```python
ValueError: The condensed distance matrix must contain only finite values.
```

Sample output in the extreme case of running with ``--skip_nucmer`` and NO pre-existing delta files at all:

```
$ rm -rf /tmp/o && average_nucleotide_identity.py -i tests/test_ani_data -o /tmp/o --labels tests/test_ani_data/labels.tab --classes tests/test_ani_data/classes.tab --noclobber --force --skip_nucmer
WARNING: Skipping NUCmer run (as instructed)!
ERROR: Missing 12 alignment lengths. There could be missing delta files if using --skip_nucmer?
Traceback (most recent call last):
  File "/home/xxx/bin/average_nucleotide_identity.py", line 4, in <module>
    __import__('pkg_resources').run_script('pyani==0.2.3.dev0', 'average_nucleotide_identity.py')
  File "/home/xxx/lib/python3.5/site-packages/pkg_resources/__init__.py", line 738, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/home/xxx/lib/python3.5/site-packages/pkg_resources/__init__.py", line 1506, in run_script
    exec(script_code, namespace, namespace)
  File "/mnt/shared/users/xxx/lib/python3.5/site-packages/pyani-0.2.3.dev0-py3.5.egg/EGG-INFO/scripts/average_nucleotide_identity.py", line 801, in <module>
  File "/mnt/shared/users/xxx/lib/python3.5/site-packages/pyani-0.2.3.dev0-py3.5.egg/EGG-INFO/scripts/average_nucleotide_identity.py", line 421, in calculate_anim
  File "/mnt/shared/users/xxx/lib/python3.5/site-packages/pyani-0.2.3.dev0-py3.5.egg/pyani/anim.py", line 205, in process_deltadir
RuntimeError: Missing 12 alignment lengths.
```