### PR TITLE
fix issue #89

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## v0.2.3.dev
 
+* fixed `--format` option so that GenBank downloads work again (issue #89)
 * add `--SGEargs` option to `average_nucleotide_identity.py` for custom qsub settings
 * `README.md` badges now clickable
 * `--version` switch added to `average_nucleotide_identity.py`


### PR DESCRIPTION
The issue reported was that the `--format` argument did not work for
downloading GenBank files. I had overlooked reimplementation of this
when adapting code for the new NCBI layouts. The lesson here is that
tests need to cover scripts (and this was already in process under
the `classify` branch).