### PR TITLE
fix issue #91 - incorrect coverage and %ID with ANIm

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## v0.2.3.dev
 
+* `ANIm` now uses `delta-filter` to remove alignments of repeat regions (issue #91)
+* added `--filter_exe` option to specify location of `delta-filter` utility (issue #91)
 * fixed `--format` option so that GenBank downloads work again (issue #89)
 * add `--SGEargs` option to `average_nucleotide_identity.py` for custom qsub settings
 * `README.md` badges now clickable

--- a/bin/average_nucleotide_identity.py
+++ b/bin/average_nucleotide_identity.py
@@ -256,6 +256,9 @@ def parse_cmdline():
     parser.add_argument("--nucmer_exe", dest="nucmer_exe",
                         action="store", default=pyani_config.NUCMER_DEFAULT,
                         help="Path to NUCmer executable")
+    parser.add_argument("--filter_exe", dest="filter_exe",
+                        action="store", default=pyani_config.FILTER_DEFAULT,
+                        help="Path to delta-filter executable")
     parser.add_argument("--blastn_exe", dest="blastn_exe",
                         action="store", default=pyani_config.BLASTN_DEFAULT,
                         help="Path to BLASTN+ executable")
@@ -386,6 +389,7 @@ def calculate_anim(infiles, org_lengths):
     if not args.skip_nucmer:
         joblist = anim.generate_nucmer_jobs(infiles, args.outdirname,
                                             nucmer_exe=args.nucmer_exe,
+                                            filter_exe=args.filter_exe,
                                             maxmatch=args.maxmatch,
                                             jobprefix=args.jobprefix)
         if args.scheduler == 'multiprocessing':

--- a/pyani/pyani_config.py
+++ b/pyani/pyani_config.py
@@ -12,6 +12,7 @@ from matplotlib.colors import LinearSegmentedColormap
 
 # Defaults assume that common binaries are on the $PATH
 NUCMER_DEFAULT = "nucmer"
+FILTER_DEFAULT = "delta-filter"
 BLASTN_DEFAULT = "blastn"
 MAKEBLASTDB_DEFAULT = "makeblastdb"
 BLASTALL_DEFAULT = "blastall"

--- a/tests/test_cmdlines.py
+++ b/tests/test_cmdlines.py
@@ -18,8 +18,10 @@ def test_anim_pairwise_basic():
     """Test generation of basic NUCmer pairwise comparison command.
     """
     cmd = anim.construct_nucmer_cmdline("file1.fna", "file2.fna")
-    assert_equal(cmd, "nucmer -mum -p ./nucmer_output/file1_vs_file2 " +
-                 "file1.fna file2.fna")
+    assert_equal(cmd, "nucmer --mum -p ./nucmer_output/file1_vs_file2 " +
+                 "file1.fna file2.fna; delta-filter -1 " +
+                 "./nucmer_output/file1_vs_file2.delta > " +
+                 "./nucmer_output/file1_vs_file2.filter")
     print(cmd)
 
 def test_anim_pairwise_maxmatch():
@@ -27,8 +29,10 @@ def test_anim_pairwise_maxmatch():
     """
     cmd = anim.construct_nucmer_cmdline("file1.fna", "file2.fna",
                                         maxmatch=True)
-    assert_equal(cmd, "nucmer -maxmatch -p ./nucmer_output/file1_vs_file2 " +
-                 "file1.fna file2.fna")
+    assert_equal(cmd, "nucmer --maxmatch -p ./nucmer_output/file1_vs_file2 " +
+                 "file1.fna file2.fna; delta-filter -1 " +
+                 "./nucmer_output/file1_vs_file2.delta > "
+                 "./nucmer_output/file1_vs_file2.filter")    
     print(cmd)
 
 
@@ -38,16 +42,28 @@ def test_anim_collection():
     """
     files = ["file1", "file2", "file3", "file4"]
     cmdlist = anim.generate_nucmer_commands(files)
-    assert_equal(cmdlist, ['nucmer -mum -p ./nucmer_output/file1_vs_file2 ' +
-                           'file1 file2',
-                           'nucmer -mum -p ./nucmer_output/file1_vs_file3 ' +
-                           'file1 file3',
-                           'nucmer -mum -p ./nucmer_output/file1_vs_file4 ' +
-                           'file1 file4',
-                           'nucmer -mum -p ./nucmer_output/file2_vs_file3 ' +
-                           'file2 file3',
-                           'nucmer -mum -p ./nucmer_output/file2_vs_file4 ' +
-                           'file2 file4',
-                           'nucmer -mum -p ./nucmer_output/file3_vs_file4 ' +
-                           'file3 file4'])
+    assert_equal(cmdlist, ['nucmer --mum -p ./nucmer_output/file1_vs_file2 ' +
+                           'file1 file2; delta-filter -1 ' +
+                           './nucmer_output/file1_vs_file2.delta > ' +
+                           './nucmer_output/file1_vs_file2.filter',
+                           'nucmer --mum -p ./nucmer_output/file1_vs_file3 ' +
+                           'file1 file3; delta-filter -1 ' +
+                           './nucmer_output/file1_vs_file3.delta > ' +
+                           './nucmer_output/file1_vs_file3.filter',
+                           'nucmer --mum -p ./nucmer_output/file1_vs_file4 ' +
+                           'file1 file4; delta-filter -1 ' +
+                           './nucmer_output/file1_vs_file4.delta > ' +
+                           './nucmer_output/file1_vs_file4.filter',
+                           'nucmer --mum -p ./nucmer_output/file2_vs_file3 ' +
+                           'file2 file3; delta-filter -1 ' +
+                           './nucmer_output/file2_vs_file3.delta > ' +
+                           './nucmer_output/file2_vs_file3.filter',
+                           'nucmer --mum -p ./nucmer_output/file2_vs_file4 ' +
+                           'file2 file4; delta-filter -1 ' +
+                           './nucmer_output/file2_vs_file4.delta > ' +
+                           './nucmer_output/file2_vs_file4.filter',
+                           'nucmer --mum -p ./nucmer_output/file3_vs_file4 ' +
+                           'file3 file4; delta-filter -1 ' +
+                           './nucmer_output/file3_vs_file4.delta > ' +
+                           './nucmer_output/file3_vs_file4.filter'])    
     print(cmdlist)


### PR DESCRIPTION
This issue arose because with NUCmer alignment some regions were
being aligned twice or more (e.g. repeats) and all alignments
contributed to the ANIm calculations. This is fixed here by
adding a delta-filter -1 step to the process, to restrict each
region of the genome to participate in only a single alignment.