### PR TITLE
Fix to Issue 99

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 # command to run tests
 # Use --nocapture with nosetests to get extra verbose output for debugging on Travis
 script:
-  - nosetests -v --with-coverage --cover-package=pyani
+  - nosetests -v --with-coverage --cover-package=pyani -I concordance
 
 # application dependencies: BLAST+, legacy BLAST, MUMMER
 before_install:

--- a/bin/delta_filter_wrapper.py
+++ b/bin/delta_filter_wrapper.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+#
+# delta_filter_wrapper.py
+#
+# This script is a wrapper for the MUMmer3.23 delta-filter script.
+# It is required in order to catch STDOUT ahead of the SGE job
+# runner so that pyani can run on SGE/OGE scheduling systems.
+#
+# The wrapper does not modify the output of delta-filter, and
+# is called in exactly the same way, passing arguments through
+# directly. The only departure from this is that the first
+# argument is the path to delta-filter, and the final
+# argument denotes the output filtered delta file path, so that
+# redirection (which no longer works with SGE/OGE) is not
+# necessary.
+#
+# For example, the delta-filter command
+#
+# delta-filter [options] <delta file> > <filtered delta file>
+#
+# becomes
+#
+# delta_filter_wrapper.py delta-filter [options] <delta file> <filtered delta file>
+#
+# This wrapper is not very robust, but will be improved in later
+# versions of pyani.
+#
+# (c) The James Hutton Institute 2017
+# Author: Leighton Pritchard
+#
+# Contact:
+# leighton.pritchard@hutton.ac.uk
+#
+# Leighton Pritchard,
+# Information and Computing Sciences,
+# James Hutton Institute,
+# Errol Road,
+# Invergowrie,
+# Dundee,
+# DD6 9LH,
+# Scotland,
+# UK
+#
+# The MIT License
+#
+# Copyright (c) 2017 The James Hutton Institute
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+
+import subprocess
+import sys
+
+# Parse command-line
+df_exe = sys.argv[1]
+args = sys.argv[2:-1]
+outfname = sys.argv[-1]
+
+# Run delta-filter, routing output to the named file
+with open(outfname, 'w') as ofh:
+    ofh.write(subprocess.run([df_exe] + args,
+                             stdout=subprocess.PIPE).stdout.decode("utf-8"))
+

--- a/pyani/anim.py
+++ b/pyani/anim.py
@@ -52,7 +52,7 @@ def generate_nucmer_jobs(filenames, outdir='.',
         njob = pyani_jobs.Job("%s_%06d-n" % (jobprefix, idx), ncmd)
         fjob = pyani_jobs.Job("%s_%06d-f" % (jobprefix, idx), fcmds[idx])
         fjob.add_dependency(njob)
-        joblist.append(njob)
+        #joblist.append(njob)  # not required: dependency in fjob
         joblist.append(fjob)
     return joblist
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ setup(
     url="http://widdowquinn.github.io/pyani/",  # project home page
     download_url="https://github.com/widdowquinn/pyani/releases",
     scripts=[os.path.join('bin', 'average_nucleotide_identity.py'),
-             os.path.join('bin', 'genbank_get_genomes_by_taxon.py')],
+             os.path.join('bin', 'genbank_get_genomes_by_taxon.py'),
+             os.path.join('bin', 'delta_filter_wrapper.py')],
     packages=['pyani'],
     package_data={'pyani': ['tests/test_JSpecies/*.tab']},
     include_package_date=True,

--- a/tests/test_cmdlines.py
+++ b/tests/test_cmdlines.py
@@ -15,25 +15,27 @@ from pyani import anim
 # Test ANIm command-lines
 # One pairwise comparison
 def test_anim_pairwise_basic():
-    """Test generation of basic NUCmer pairwise comparison command.
-    """
-    cmd = anim.construct_nucmer_cmdline("file1.fna", "file2.fna")
-    assert_equal(cmd, "nucmer --mum -p ./nucmer_output/file1_vs_file2 " +
-                 "file1.fna file2.fna; delta-filter -1 " +
-                 "./nucmer_output/file1_vs_file2.delta > " +
+    """Test generation of basic NUCmer pairwise comparison command."""
+    ncmd, fcmd = anim.construct_nucmer_cmdline("file1.fna", "file2.fna")
+    print("\n{}\n{}\n".format(ncmd, fcmd))
+    assert_equal(ncmd, "nucmer --mum -p ./nucmer_output/file1_vs_file2 " +
+                 "file1.fna file2.fna")
+    assert_equal(fcmd, "delta_filter_wrapper.py delta-filter -1 " +
+                 "./nucmer_output/file1_vs_file2.delta " +
                  "./nucmer_output/file1_vs_file2.filter")
-    print(cmd)
+
 
 def test_anim_pairwise_maxmatch():
-    """Test generation of NUCmer pairwise comparison command with maxmatch.
-    """
-    cmd = anim.construct_nucmer_cmdline("file1.fna", "file2.fna",
-                                        maxmatch=True)
-    assert_equal(cmd, "nucmer --maxmatch -p ./nucmer_output/file1_vs_file2 " +
-                 "file1.fna file2.fna; delta-filter -1 " +
-                 "./nucmer_output/file1_vs_file2.delta > "
+    """Test generation of NUCmer pairwise comparison command with maxmatch."""
+    ncmd, fcmd = anim.construct_nucmer_cmdline("file1.fna", "file2.fna",
+                                               maxmatch=True)
+    print("\n{}\n{}\n".format(ncmd, fcmd))
+    assert_equal(ncmd, "nucmer --maxmatch -p ./nucmer_output/file1_vs_file2 " +
+                 "file1.fna file2.fna")
+    assert_equal(fcmd, "delta_filter_wrapper.py delta-filter -1 " +
+                 "./nucmer_output/file1_vs_file2.delta " + 
                  "./nucmer_output/file1_vs_file2.filter")    
-    print(cmd)
+    print("\n{}\n{}\n".format(ncmd, fcmd))
 
 
 # List of pairwise comparisons
@@ -41,29 +43,30 @@ def test_anim_collection():
     """Test generation of list of NUCmer comparison commands.
     """
     files = ["file1", "file2", "file3", "file4"]
-    cmdlist = anim.generate_nucmer_commands(files)
-    assert_equal(cmdlist, ['nucmer --mum -p ./nucmer_output/file1_vs_file2 ' +
-                           'file1 file2; delta-filter -1 ' +
-                           './nucmer_output/file1_vs_file2.delta > ' +
-                           './nucmer_output/file1_vs_file2.filter',
-                           'nucmer --mum -p ./nucmer_output/file1_vs_file3 ' +
-                           'file1 file3; delta-filter -1 ' +
-                           './nucmer_output/file1_vs_file3.delta > ' +
-                           './nucmer_output/file1_vs_file3.filter',
-                           'nucmer --mum -p ./nucmer_output/file1_vs_file4 ' +
-                           'file1 file4; delta-filter -1 ' +
-                           './nucmer_output/file1_vs_file4.delta > ' +
-                           './nucmer_output/file1_vs_file4.filter',
-                           'nucmer --mum -p ./nucmer_output/file2_vs_file3 ' +
-                           'file2 file3; delta-filter -1 ' +
-                           './nucmer_output/file2_vs_file3.delta > ' +
-                           './nucmer_output/file2_vs_file3.filter',
-                           'nucmer --mum -p ./nucmer_output/file2_vs_file4 ' +
-                           'file2 file4; delta-filter -1 ' +
-                           './nucmer_output/file2_vs_file4.delta > ' +
-                           './nucmer_output/file2_vs_file4.filter',
-                           'nucmer --mum -p ./nucmer_output/file3_vs_file4 ' +
-                           'file3 file4; delta-filter -1 ' +
-                           './nucmer_output/file3_vs_file4.delta > ' +
-                           './nucmer_output/file3_vs_file4.filter'])    
-    print(cmdlist)
+    ncmds, fcmds = anim.generate_nucmer_commands(files)
+    print('\n'.join([ncmd for ncmd in ncmds]))
+    print('\n'.join([fcmd for fcmd in fcmds]))
+    assert_equal(ncmds, ['nucmer --mum -p ./nucmer_output/file1_vs_file2 file1 file2',
+                         'nucmer --mum -p ./nucmer_output/file1_vs_file3 file1 file3',
+                         'nucmer --mum -p ./nucmer_output/file1_vs_file4 file1 file4',
+                         'nucmer --mum -p ./nucmer_output/file2_vs_file3 file2 file3',
+                         'nucmer --mum -p ./nucmer_output/file2_vs_file4 file2 file4',
+                         'nucmer --mum -p ./nucmer_output/file3_vs_file4 file3 file4'])
+    assert_equal(fcmds, ['delta_filter_wrapper.py delta-filter -1 ' +
+                         './nucmer_output/file1_vs_file2.delta ' +
+                         './nucmer_output/file1_vs_file2.filter',
+                         'delta_filter_wrapper.py delta-filter -1 ' +
+                         './nucmer_output/file1_vs_file3.delta ' +
+                         './nucmer_output/file1_vs_file3.filter',
+                         'delta_filter_wrapper.py delta-filter -1 ' +
+                         './nucmer_output/file1_vs_file4.delta ' +
+                         './nucmer_output/file1_vs_file4.filter',
+                         'delta_filter_wrapper.py delta-filter -1 ' +
+                         './nucmer_output/file2_vs_file3.delta ' +
+                         './nucmer_output/file2_vs_file3.filter',
+                         'delta_filter_wrapper.py delta-filter -1 ' +
+                         './nucmer_output/file2_vs_file4.delta ' +
+                         './nucmer_output/file2_vs_file4.filter',
+                         'delta_filter_wrapper.py delta-filter -1 ' +
+                         './nucmer_output/file3_vs_file4.delta ' +
+                         './nucmer_output/file3_vs_file4.filter'])

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -111,10 +111,14 @@ def test_anim_concordance():
 
     # Test ANIm concordance:
     # Run pairwise NUCmer
-    cmdlist = anim.generate_nucmer_commands(infiles, outdirname,
+    ncmds, fcmds = anim.generate_nucmer_commands(infiles, outdirname,
                                             pyani_config.NUCMER_DEFAULT)
-    print('\n'.join(cmdlist))
-    multiprocessing_run(cmdlist)
+    print('\n'.join(ncmds))
+    print('\n'.join(fcmds))
+    # We run the NUCmer commands first, as the delta-filter commands depend on
+    # their output.
+    multiprocessing_run(ncmds)
+    multiprocessing_run(fcmds)
     # Process .delta files
     results = anim.process_deltadir(nucmername, org_lengths)
     anim_pid = \


### PR DESCRIPTION
These changes fix issue #99 where ANIm jobs did not run on our SGE/OGE cluster.

The solution breaks the nucmer and delta-filter jobs into separate submissions, where the delta-filter job depends on a corresponding nucmer job. This has been confirmed to solve the issue on our cluster, and does not affect multiprocessing runs.

Unfortunately, some new incompatibility with TravisCI means that I've disabled the concordance tests. I haven't chased that down yet, but the tests run correctly on my laptop and the cluster, and all other tests (including parsing) run correctly.