### PR TITLE
Add index example

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -4,7 +4,7 @@
 Examples
 ========
 
-Using ``pyani index``
+Using arbirary sequences with ``pyani index``
 ---------------------
 
 ``pyani index`` is used to created the required ``.md5`` files for each genome, as well as the ``classes.txt`` and ``labels.txt``, which will come in handy later on for labelling the datasets.  Say the directory ``./mygenomes/`` contains fasta-formated sequences of interest.  Running the following command will prepare the files for database construction
@@ -12,7 +12,7 @@ Using ``pyani index``
 ::
     pyani index ./mygenomes/ -v -l mygenomes_logfile.txt
 
-Now, the directory will contain the original ``.fasta`` files as well as ``classes.txt`` and ``labels.txt``.  ``./mygenomes/` can now be used with the rest of the ``pyani`` workflow.
+Now, the directory will contain the original ``.fasta`` files as well as ``classes.txt`` and ``labels.txt``.  ``./mygenomes/`` can now be used with the rest of the ``pyani`` workflow.
 
 
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -3,3 +3,16 @@
 ========
 Examples
 ========
+
+Using ``pyani index``
+---------------------
+
+``pyani index`` is used to created the required ``.md5`` files for each genome, as well as the ``classes.txt`` and ``labels.txt``, which will come in handy later on for labelling the datasets.  Say the directory ``./mygenomes/`` contains fasta-formated sequences of interest.  Running the following command will prepare the files for database construction
+
+::
+    pyani index ./mygenomes/ -v -l mygenomes_logfile.txt
+
+Now, the directory will contain the original ``.fasta`` files as well as ``classes.txt`` and ``labels.txt``.  ``./mygenomes/` can now be used with the rest of the ``pyani`` workflow.
+
+
+


### PR DESCRIPTION
Take #2:  Add example usage for `pyani index` to the readthedocs "Examples" page.