### PR TITLE
change print(args) statement to stderr

### DIFF
--- a/pyani/scripts/pyani_script.py
+++ b/pyani/scripts/pyani_script.py
@@ -57,7 +57,7 @@ def run_main(argv=None, logger=None):
     else:
         args = parse_cmdline(argv)
 
-    print(args)
+    sys.stderr.write(str(args) + "\n")
 
     # Catch execution with no arguments
     if len(sys.argv) == 1:


### PR DESCRIPTION
There may be advantages of using `print` that I haven't thought about, but changing this args namespace message to stderr keeps it out of piped output.