### PR TITLE
Add `--force` commandline argument to `pyani index`

### DIFF
--- a/pyani/scripts/parsers.py
+++ b/pyani/scripts/parsers.py
@@ -254,6 +254,9 @@ def build_parser_index(subps, parents=None):
     parser.add_argument("--classes", dest="classfname",
                         action="store", default="classes.txt",
                         help="Filename for classes file")
+    parser.add_argument("-f", "--force", action='store_true',
+                        dest='force', default=False,
+                        help='force creation of new class and index files')
     parser.set_defaults(func=subcommands.subcmd_index)
 
 

--- a/pyani/scripts/pyani_script.py
+++ b/pyani/scripts/pyani_script.py
@@ -57,7 +57,7 @@ def run_main(argv=None, logger=None):
     else:
         args = parse_cmdline(argv)
 
-    print(args)
+    sys.stderr.write(str(args) + "\n")
 
     # Catch execution with no arguments
     if len(sys.argv) == 1:

--- a/pyani/scripts/subcommands.py
+++ b/pyani/scripts/subcommands.py
@@ -285,8 +285,14 @@ def subcmd_index(args, logger):
     classfname = os.path.join(args.indir, args.classfname)
     logger.info("Writing classes file to %s", classfname)
     if os.path.exists(classfname):
-        logger.warning("Class file %s exists, not overwriting",
-                       classfname)
+        if not args.force:
+            logger.warning("Class file %s exists, not overwriting",
+                           classfname)
+        else:
+            logger.warning("Class file %s exists, but forcing overwrite",
+                           classfname)
+            with open(classfname, "w") as ofh:
+                ofh.write('\n'.join(classes) + '\n')
     else:
         with open(classfname, "w") as ofh:
             ofh.write('\n'.join(classes) + '\n')
@@ -294,8 +300,14 @@ def subcmd_index(args, logger):
     labelfname = os.path.join(args.indir, args.labelfname)
     logger.info("Writing labels file to %s", labelfname)
     if os.path.exists(labelfname):
-        logger.warning("Labels file %s exists, not overwriting",
-                       labelfname)
+        if not args.force:
+            logger.warning("Labels file %s exists, not overwriting",
+                           labelfname)
+        else:
+            logger.warning("Labels file %s exists, but foring overwrite",
+                           labelfname)
+            with open(classfname, "w") as ofh:
+                ofh.write('\n'.join(classes) + '\n')            
     else:
         with open(labelfname, "w") as ofh:
             ofh.write('\n'.join(labels) + '\n')

--- a/pyani/scripts/subcommands.py
+++ b/pyani/scripts/subcommands.py
@@ -268,6 +268,13 @@ def subcmd_index(args, logger):
         hashfname = os.path.splitext(fpath)[0] + '.md5'
         if os.path.isfile(hashfname):
             logger.info("%s already indexed (skipping)", fpath)
+            if args.force:
+                # Parse the file and get the label/class information
+                with open(fpath, "r") as sfh:
+                    label = list(SeqIO.parse(sfh, 'fasta'))[0].description
+                datahash = download.create_hash(fpath)
+                labels.append('\t'.join([datahash, fstem, label]))
+                classes.append('\t'.join([datahash, fstem, label]))
         else:
             # Write an .md5 hash file
             datahash = download.create_hash(fpath)
@@ -304,10 +311,10 @@ def subcmd_index(args, logger):
             logger.warning("Labels file %s exists, not overwriting",
                            labelfname)
         else:
-            logger.warning("Labels file %s exists, but foring overwrite",
+            logger.warning("Labels file %s exists, but forcing overwrite",
                            labelfname)
-            with open(classfname, "w") as ofh:
-                ofh.write('\n'.join(classes) + '\n')            
+            with open(labelfname, "w") as ofh:
+                ofh.write('\n'.join(labels) + '\n')            
     else:
         with open(labelfname, "w") as ofh:
             ofh.write('\n'.join(labels) + '\n')


### PR DESCRIPTION
I ended up spending a good bit of time troubleshooting a silly self-inflicted db issue that ended up stemming from having an outdated `labels.txt` and `classes.txt` file, as these are only generated when one is not already present.  Here, I added a commandline argument to optionally force the creation of new labels and classes.

The code itself looks a bit repetitive, mostly because I wanted to have slightly different logging messages depending on the circumstances which results in writing a new file.

If you think that this `-force` arg is worth having, I suppose one question would be whether this should clobber the existing .md5 files as well.  Currently the parser message tries to state that just the classes/labels are being re-written, but it may generate confusion as to which files are being re-created if people don't read the docs...

