### PR TITLE
Disable blastall

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 sudo: required
+dist: xenial
 python:
   - "3.5"
   - "3.5-dev"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,13 @@ python:
   - "3.5-dev"
   - "3.6"
   - "3.6-dev"
-  - "3.7"
-  - "3.7-dev"
+  
+# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: python
+sudo: required
 python:
   - "3.5"
-  - "3.5-dev" # 3.5 development branch
+  - "3.5-dev"
   - "3.6"
-  - "3.6-dev" # 3.6 development branch
-#  - "nightly" # currently points to 3.7-dev
+  - "3.6-dev"
+  - "3.7"
+  - "3.7-dev"
 
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,6 @@ script:
 # application dependencies: BLAST+, legacy BLAST, MUMMER
 before_install:
   - cd $HOME
-  - wget http://mirrors.vbi.vt.edu/mirrors/ftp.ncbi.nih.gov/blast/executables/blast+/2.2.26/blast-2.2.26-x64-linux.tar.gz
-  - tar -zxvf blast-2.2.26-x64-linux.tar.gz
-  - export PATH=$HOME/blast-2.2.26/bin:$PATH
   - cd $TRAVIS_BUILD_DIR
 
 sudo: false

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## v0.2.7.dev
 
-* update legacy BLAST download location in TravisCI
+* deprecate legacy BLAST testing: `ANIblastall` commands still work, but are no longer supported
 * update concordance tests (issue #105)
 * extend test suites (issue #104)
 * modify ANIm concordance test to accommodate new command structure

--- a/pyani/anib.py
+++ b/pyani/anib.py
@@ -44,7 +44,7 @@ Goris et al. We persist with their definition, however.  Only these
 qualifying matches contribute to the total aligned length, and total
 aligned sequence identity used to calculate ANI.
 
-(c) The James Hutton Institute 2013-2017
+(c) The James Hutton Institute 2013-2018
 Author: Leighton Pritchard
 
 Contact:
@@ -62,7 +62,7 @@ UK
 
 The MIT License
 
-Copyright (c) 2016-2017 The James Hutton Institute
+Copyright (c) 2013-2018 The James Hutton Institute
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -114,19 +114,19 @@ def fragment_fasta_files(infiles, outdirname, fragsize):
     outfnames = []
     for fname in infiles:
         outstem, outext = os.path.splitext(os.path.split(fname)[-1])
-        outfname = os.path.join(outdirname, outstem) + '-fragments' + outext
+        outfname = os.path.join(outdirname, outstem) + "-fragments" + outext
         outseqs = []
         count = 0
-        for seq in SeqIO.parse(fname, 'fasta'):
+        for seq in SeqIO.parse(fname, "fasta"):
             idx = 0
             while idx < len(seq):
                 count += 1
-                newseq = seq[idx:idx+fragsize]
+                newseq = seq[idx : idx + fragsize]
                 newseq.id = "frag%05d" % count
                 outseqs.append(newseq)
                 idx += fragsize
         outfnames.append(outfname)
-        SeqIO.write(outseqs, outfname, 'fasta')
+        SeqIO.write(outseqs, outfname, "fasta")
     return outfnames, get_fraglength_dict(outfnames)
 
 
@@ -142,7 +142,7 @@ def get_fraglength_dict(fastafiles):
     """
     fraglength_dict = {}
     for filename in fastafiles:
-        qname = os.path.split(filename)[-1].split('-fragments')[0]
+        qname = os.path.split(filename)[-1].split("-fragments")[0]
         fraglength_dict[qname] = get_fragment_lengths(filename)
     return fraglength_dict
 
@@ -157,7 +157,7 @@ def get_fragment_lengths(fastafile):
     NOTE: ambiguity symbols are not discounted.
     """
     fraglengths = {}
-    for seq in SeqIO.parse(fastafile, 'fasta'):
+    for seq in SeqIO.parse(fastafile, "fasta"):
         fraglengths[seq.id] = len(seq)
     return fraglengths
 
@@ -169,31 +169,36 @@ def build_db_jobs(infiles, blastcmds):
     # Create dictionary of database building jobs, keyed by db name
     # defining jobnum for later use as last job index used
     for idx, fname in enumerate(infiles):
-        dbjobdict[blastcmds.get_db_name(fname)] = \
-                pyani_jobs.Job("%s_db_%06d" % (blastcmds.prefix, idx),
-                               blastcmds.build_db_cmd(fname))
+        dbjobdict[blastcmds.get_db_name(fname)] = pyani_jobs.Job(
+            "%s_db_%06d" % (blastcmds.prefix, idx), blastcmds.build_db_cmd(fname)
+        )
     return dbjobdict
 
 
-def make_blastcmd_builder(mode, outdir, format_exe=None, blast_exe=None,
-                          prefix="ANIBLAST"):
+def make_blastcmd_builder(
+    mode, outdir, format_exe=None, blast_exe=None, prefix="ANIBLAST"
+):
     """Returns BLASTcmds object for construction of BLAST commands."""
     if mode == "ANIb":  # BLAST/formatting executable depends on mode
-        blastcmds = BLASTcmds(BLASTfunctions(construct_makeblastdb_cmd,
-                                             construct_blastn_cmdline),
-                              BLASTexes(format_exe or \
-                                        pyani_config.MAKEBLASTDB_DEFAULT,
-                                        blast_exe or \
-                                        pyani_config.BLASTN_DEFAULT),
-                              prefix, outdir)
+        blastcmds = BLASTcmds(
+            BLASTfunctions(construct_makeblastdb_cmd, construct_blastn_cmdline),
+            BLASTexes(
+                format_exe or pyani_config.MAKEBLASTDB_DEFAULT,
+                blast_exe or pyani_config.BLASTN_DEFAULT,
+            ),
+            prefix,
+            outdir,
+        )
     else:
-        blastcmds = BLASTcmds(BLASTfunctions(construct_formatdb_cmd,
-                                             construct_blastall_cmdline),
-                              BLASTexes(format_exe or \
-                                        pyani_config.FORMATDB_DEFAULT,
-                                        blast_exe or \
-                                        pyani_config.BLASTALL_DEFAULT),
-                              prefix, outdir)
+        blastcmds = BLASTcmds(
+            BLASTfunctions(construct_formatdb_cmd, construct_blastall_cmdline),
+            BLASTexes(
+                format_exe or pyani_config.FORMATDB_DEFAULT,
+                blast_exe or pyani_config.BLASTALL_DEFAULT,
+            ),
+            prefix,
+            outdir,
+        )
     return blastcmds
 
 
@@ -213,7 +218,7 @@ def make_job_graph(infiles, fragfiles, blastcmds):
     How those jobs are scheduled depends on the scheduler (see
     run_multiprocessing.py, run_sge.py)
     """
-    joblist = []    # Holds list of job dependency graphs
+    joblist = []  # Holds list of job dependency graphs
 
     # Get dictionary of database-building jobs
     dbjobdict = build_db_jobs(infiles, blastcmds)
@@ -221,21 +226,20 @@ def make_job_graph(infiles, fragfiles, blastcmds):
     # Create list of BLAST executable jobs, with dependencies
     jobnum = len(dbjobdict)
     for idx, fname1 in enumerate(fragfiles[:-1]):
-        for fname2 in fragfiles[idx+1:]:
+        for fname2 in fragfiles[idx + 1 :]:
             jobnum += 1
-            jobs = \
-                [pyani_jobs.Job("%s_exe_%06d_a" %
-                                (blastcmds.prefix, jobnum),
-                                blastcmds.build_blast_cmd(fname1,
-                                                          fname2.replace\
-                                                          ('-fragments', ''))),
-                 pyani_jobs.Job("%s_exe_%06d_b" %
-                                (blastcmds.prefix, jobnum),
-                                blastcmds.build_blast_cmd(fname2,
-                                                          fname1.replace\
-                                                          ('-fragments', '')))]
-            jobs[0].add_dependency(dbjobdict[fname1.replace('-fragments', '')])
-            jobs[1].add_dependency(dbjobdict[fname2.replace('-fragments', '')])
+            jobs = [
+                pyani_jobs.Job(
+                    "%s_exe_%06d_a" % (blastcmds.prefix, jobnum),
+                    blastcmds.build_blast_cmd(fname1, fname2.replace("-fragments", "")),
+                ),
+                pyani_jobs.Job(
+                    "%s_exe_%06d_b" % (blastcmds.prefix, jobnum),
+                    blastcmds.build_blast_cmd(fname2, fname1.replace("-fragments", "")),
+                ),
+            ]
+            jobs[0].add_dependency(dbjobdict[fname1.replace("-fragments", "")])
+            jobs[1].add_dependency(dbjobdict[fname2.replace("-fragments", "")])
             joblist.extend(jobs)
 
     # Return the dependency graph
@@ -243,8 +247,7 @@ def make_job_graph(infiles, fragfiles, blastcmds):
 
 
 # Generate list of makeblastdb command lines from passed filenames
-def generate_blastdb_commands(filenames, outdir, blastdb_exe=None,
-                              mode="ANIb"):
+def generate_blastdb_commands(filenames, outdir, blastdb_exe=None, mode="ANIb"):
     """Return a list of makeblastdb command-lines for ANIb/ANIblastall
 
     - filenames - a list of paths to input FASTA files
@@ -256,17 +259,18 @@ def generate_blastdb_commands(filenames, outdir, blastdb_exe=None,
     else:
         construct_db_cmdline = construct_formatdb_cmd
     if blastdb_exe is None:
-        cmdlines = [construct_db_cmdline(fname, outdir) for
-                    fname in filenames]
+        cmdlines = [construct_db_cmdline(fname, outdir) for fname in filenames]
     else:
-        cmdlines = [construct_db_cmdline(fname, outdir, blastdb_exe) for
-                    fname in filenames]        
+        cmdlines = [
+            construct_db_cmdline(fname, outdir, blastdb_exe) for fname in filenames
+        ]
     return cmdlines
 
 
 # Generate single makeblastdb command line
-def construct_makeblastdb_cmd(filename, outdir,
-                              blastdb_exe=pyani_config.MAKEBLASTDB_DEFAULT):
+def construct_makeblastdb_cmd(
+    filename, outdir, blastdb_exe=pyani_config.MAKEBLASTDB_DEFAULT
+):
     """Returns a single makeblastdb command.
 
     - filename - input filename
@@ -274,16 +278,16 @@ def construct_makeblastdb_cmd(filename, outdir,
     """
     title = os.path.splitext(os.path.split(filename)[-1])[0]
     outfilename = os.path.join(outdir, os.path.split(filename)[-1])
-    return ("{0} -dbtype nucl -in {1} -title {2} -out {3}".format(blastdb_exe,
-                                                                  filename,
-                                                                  title,
-                                                                  outfilename),
-            outfilename)
+    return (
+        "{0} -dbtype nucl -in {1} -title {2} -out {3}".format(
+            blastdb_exe, filename, title, outfilename
+        ),
+        outfilename,
+    )
 
 
 # Generate single makeblastdb command line
-def construct_formatdb_cmd(filename, outdir,
-                           blastdb_exe=pyani_config.FORMATDB_DEFAULT):
+def construct_formatdb_cmd(filename, outdir, blastdb_exe=pyani_config.FORMATDB_DEFAULT):
     """Returns a single formatdb command.
 
     - filename - input filename
@@ -292,8 +296,10 @@ def construct_formatdb_cmd(filename, outdir,
     title = os.path.splitext(os.path.split(filename)[-1])[0]
     newfilename = os.path.join(outdir, os.path.split(filename)[-1])
     shutil.copy(filename, newfilename)
-    return ("{0} -p F -i {1} -t {2}".format(blastdb_exe, newfilename, title),
-            newfilename)
+    return (
+        "{0} -p F -i {1} -t {2}".format(blastdb_exe, newfilename, title),
+        newfilename,
+    )
 
 
 # Generate list of BLASTN command lines from passed filenames
@@ -315,25 +321,26 @@ def generate_blastn_commands(filenames, outdir, blast_exe=None, mode="ANIb"):
         construct_blast_cmdline = construct_blastall_cmdline
     cmdlines = []
     for idx, fname1 in enumerate(filenames[:-1]):
-        dbname1 = fname1.replace('-fragments', '')
-        for fname2 in filenames[idx+1:]:
-            dbname2 = fname2.replace('-fragments', '')
+        dbname1 = fname1.replace("-fragments", "")
+        for fname2 in filenames[idx + 1 :]:
+            dbname2 = fname2.replace("-fragments", "")
             if blast_exe is None:
-                cmdlines.append(construct_blast_cmdline(fname1, dbname2,
-                                                        outdir))
-                cmdlines.append(construct_blast_cmdline(fname2, dbname1,
-                                                        outdir))
+                cmdlines.append(construct_blast_cmdline(fname1, dbname2, outdir))
+                cmdlines.append(construct_blast_cmdline(fname2, dbname1, outdir))
             else:
-                cmdlines.append(construct_blast_cmdline(fname1, dbname2,
-                                                        outdir, blast_exe))
-                cmdlines.append(construct_blast_cmdline(fname2, dbname1,
-                                                        outdir, blast_exe))
+                cmdlines.append(
+                    construct_blast_cmdline(fname1, dbname2, outdir, blast_exe)
+                )
+                cmdlines.append(
+                    construct_blast_cmdline(fname2, dbname1, outdir, blast_exe)
+                )
     return cmdlines
 
 
 # Generate single BLASTN command line
-def construct_blastn_cmdline(fname1, fname2, outdir,
-                             blastn_exe=pyani_config.BLASTN_DEFAULT):
+def construct_blastn_cmdline(
+    fname1, fname2, outdir, blastn_exe=pyani_config.BLASTN_DEFAULT
+):
     """Returns a single blastn command.
 
     - filename - input filename
@@ -341,36 +348,48 @@ def construct_blastn_cmdline(fname1, fname2, outdir,
     """
     fstem1 = os.path.splitext(os.path.split(fname1)[-1])[0]
     fstem2 = os.path.splitext(os.path.split(fname2)[-1])[0]
-    fstem1 = fstem1.replace('-fragments', '')
+    fstem1 = fstem1.replace("-fragments", "")
     prefix = os.path.join(outdir, "%s_vs_%s" % (fstem1, fstem2))
-    cmd = "{0} -out {1}.blast_tab -query {2} -db {3} " +\
-        "-xdrop_gap_final 150 -dust no -evalue 1e-15 " +\
-        "-max_target_seqs 1 -outfmt '6 qseqid sseqid length mismatch " +\
-        "pident nident qlen slen qstart qend sstart send positive " +\
-        "ppos gaps' -task blastn"
+    cmd = (
+        "{0} -out {1}.blast_tab -query {2} -db {3} "
+        + "-xdrop_gap_final 150 -dust no -evalue 1e-15 "
+        + "-max_target_seqs 1 -outfmt '6 qseqid sseqid length mismatch "
+        + "pident nident qlen slen qstart qend sstart send positive "
+        + "ppos gaps' -task blastn"
+    )
     return cmd.format(blastn_exe, prefix, fname1, fname2)
 
 
 # Generate single BLASTALL command line
-def construct_blastall_cmdline(fname1, fname2, outdir,
-                               blastall_exe=pyani_config.BLASTALL_DEFAULT):
+def construct_blastall_cmdline(
+    fname1, fname2, outdir, blastall_exe=pyani_config.BLASTALL_DEFAULT
+):
     """Returns a single blastall command.
 
     - blastall_exe - path to BLASTALL executable
     """
     fstem1 = os.path.splitext(os.path.split(fname1)[-1])[0]
     fstem2 = os.path.splitext(os.path.split(fname2)[-1])[0]
-    fstem1 = fstem1.replace('-fragments', '')
+    fstem1 = fstem1.replace("-fragments", "")
     prefix = os.path.join(outdir, "%s_vs_%s" % (fstem1, fstem2))
-    cmd = "{0} -p blastn -o {1}.blast_tab -i {2} -d {3} " +\
-        "-X 150 -q -1 -F F -e 1e-15 " +\
-        "-b 1 -v 1 -m 8"
+    cmd = (
+        "{0} -p blastn -o {1}.blast_tab -i {2} -d {3} "
+        + "-X 150 -q -1 -F F -e 1e-15 "
+        + "-b 1 -v 1 -m 8"
+    )
     return cmd.format(blastall_exe, prefix, fname1, fname2)
 
 
 # Process pairwise BLASTN output
-def process_blast(blast_dir, org_lengths, fraglengths=None, mode="ANIb",
-                  identity=0.3, coverage=0.7, logger=None):
+def process_blast(
+    blast_dir,
+    org_lengths,
+    fraglengths=None,
+    mode="ANIb",
+    identity=0.3,
+    coverage=0.7,
+    logger=None,
+):
     """Returns a tuple of ANIb results for .blast_tab files in the output dir.
 
     - blast_dir - path to the directory containing .blast_tab files
@@ -392,7 +411,7 @@ def process_blast(blast_dir, org_lengths, fraglengths=None, mode="ANIb",
     very distant sequence was included in the analysis.
     """
     # Process directory to identify input files
-    blastfiles = pyani_files.get_input_files(blast_dir, '.blast_tab')
+    blastfiles = pyani_files.get_input_files(blast_dir, ".blast_tab")
     # Hold data in ANIResults object
     results = ANIResults(list(org_lengths.keys()), mode)
 
@@ -403,23 +422,25 @@ def process_blast(blast_dir, org_lengths, fraglengths=None, mode="ANIb",
     # Process .blast_tab files assuming that the filename format holds:
     # org1_vs_org2.blast_tab:
     for blastfile in blastfiles:
-        qname, sname = \
-            os.path.splitext(os.path.split(blastfile)[-1])[0].split('_vs_')
+        qname, sname = os.path.splitext(os.path.split(blastfile)[-1])[0].split("_vs_")
 
         # We may have BLAST files from other analyses in the same directory
         # If this occurs, we raise a warning, and skip the file
         if qname not in list(org_lengths.keys()):
             if logger:
-                logger.warning("Query name %s not in input " % qname +
-                               "sequence list, skipping %s" % blastfile)
+                logger.warning(
+                    "Query name %s not in input " % qname
+                    + "sequence list, skipping %s" % blastfile
+                )
             continue
         if sname not in list(org_lengths.keys()):
             if logger:
-                logger.warning("Subject name %s not in input " % sname +
-                               "sequence list, skipping %s" % blastfile)
+                logger.warning(
+                    "Subject name %s not in input " % sname
+                    + "sequence list, skipping %s" % blastfile
+                )
             continue
-        resultvals = parse_blast_tab(blastfile, fraglengths,
-                                     identity, coverage, mode)
+        resultvals = parse_blast_tab(blastfile, fraglengths, identity, coverage, mode)
         query_cover = float(resultvals[0]) / org_lengths[qname]
 
         # Populate dataframes: when assigning data, we need to note that
@@ -451,39 +472,62 @@ def parse_blast_tab(filename, fraglengths, identity, coverage, mode="ANIb"):
     '''
     """
     # Assuming that the filename format holds org1_vs_org2.blast_tab:
-    qname = os.path.splitext(os.path.split(filename)[-1])[0].split('_vs_')[0]
+    qname = os.path.splitext(os.path.split(filename)[-1])[0].split("_vs_")[0]
     # Load output as dataframe
     if mode == "ANIblastall":
         qfraglengths = fraglengths[qname]
-        columns = ['sid', 'blast_pid', 'blast_alnlen', 'blast_mismatch',
-                   'blast_gaps', 'q_start', 'q_end', 's_start', 's_end',
-                   'e_Value', 'bit_score']
+        columns = [
+            "sid",
+            "blast_pid",
+            "blast_alnlen",
+            "blast_mismatch",
+            "blast_gaps",
+            "q_start",
+            "q_end",
+            "s_start",
+            "s_end",
+            "e_Value",
+            "bit_score",
+        ]
     else:
-        columns = ['sbjct_id', 'blast_alnlen', 'blast_mismatch',
-                   'blast_pid', 'blast_identities', 'qlen', 'slen',
-                   'q_start', 'q_end', 's_start', 's_end', 'blast_pos',
-                   'ppos', 'blast_gaps']
+        columns = [
+            "sbjct_id",
+            "blast_alnlen",
+            "blast_mismatch",
+            "blast_pid",
+            "blast_identities",
+            "qlen",
+            "slen",
+            "q_start",
+            "q_end",
+            "s_start",
+            "s_end",
+            "blast_pos",
+            "ppos",
+            "blast_gaps",
+        ]
     # We may receive an empty BLASTN output file, if there are no significant
     # regions of homology. This causes pandas to throw an error on CSV import.
     # To get past this, we create an empty dataframe with the appropriate
     # columns.
     try:
-        data = pd.read_csv(filename, header=None, sep='\t', index_col=0)
+        data = pd.read_csv(filename, header=None, sep="\t", index_col=0)
         data.columns = columns
     except pd.io.common.EmptyDataError:
         data = pd.DataFrame(columns=columns)
     # Add new column for fragment length, only for BLASTALL
     if mode == "ANIblastall":
-        data['qlen'] = pd.Series([qfraglengths[idx] for idx in data.index],
-                                 index=data.index)
+        data["qlen"] = pd.Series(
+            [qfraglengths[idx] for idx in data.index], index=data.index
+        )
     # Add new columns for recalculated alignment length, proportion, and
     # percentage identity
-    data['ani_alnlen'] = data['blast_alnlen'] - data['blast_gaps']
-    data['ani_alnids'] = data['ani_alnlen'] - data['blast_mismatch']
-    data['ani_coverage'] = data['ani_alnlen'] / data['qlen']
-    data['ani_pid'] = data['ani_alnids'] / data['qlen']
+    data["ani_alnlen"] = data["blast_alnlen"] - data["blast_gaps"]
+    data["ani_alnids"] = data["ani_alnlen"] - data["blast_mismatch"]
+    data["ani_coverage"] = data["ani_alnlen"] / data["qlen"]
+    data["ani_pid"] = data["ani_alnids"] / data["qlen"]
     # Filter rows on 'ani_coverage' > 0.7, 'ani_pid' > 0.3
-    filtered = data[(data['ani_coverage'] > coverage) & (data['ani_pid'] > identity)]
+    filtered = data[(data["ani_coverage"] > coverage) & (data["ani_pid"] > identity)]
     # Dedupe query hits, so we only take the best hit
     filtered = filtered.groupby(filtered.index).first()
     # Replace NaNs with zero
@@ -498,11 +542,10 @@ def parse_blast_tab(filename, fraglengths, identity, coverage, mode="ANIb"):
     # of rounding differences (e.g. coverage being close to 70%).
     # NOTE: If there are no hits, then ani_pid will be nan - we replace this
     # with zero if that happens
-    ani_pid = filtered['blast_pid'].mean()
+    ani_pid = filtered["blast_pid"].mean()
     if pd.isnull(ani_pid):  # Happens if there are no matches in ANIb
         ani_pid = 0
-    aln_length = filtered['ani_alnlen'].sum()
-    sim_errors = filtered['blast_mismatch'].sum() +\
-        filtered['blast_gaps'].sum()
-    filtered.to_csv(filename + '.dataframe', sep="\t")
+    aln_length = filtered["ani_alnlen"].sum()
+    sim_errors = filtered["blast_mismatch"].sum() + filtered["blast_gaps"].sum()
+    filtered.to_csv(filename + ".dataframe", sep="\t")
     return aln_length, sim_errors, ani_pid

--- a/tests/test_anib.py
+++ b/tests/test_anib.py
@@ -55,10 +55,10 @@ import unittest
 
 import pandas as pd
 
-from nose.tools import (assert_equal,)
-from pandas.util.testing import (assert_frame_equal,)
+from nose.tools import assert_equal, nottest
+from pandas.util.testing import assert_frame_equal
 
-from pyani import (anib, pyani_files)
+from pyani import anib, pyani_files
 
 
 class TestBLASTCmdline(unittest.TestCase):
@@ -67,215 +67,336 @@ class TestBLASTCmdline(unittest.TestCase):
 
     def setUp(self):
         """Set parameters for tests."""
-        self.indir = os.path.join('tests', 'test_input', 'anib')
-        self.outdir = os.path.join('tests', 'test_output', 'anib')
-        self.seqdir = os.path.join('tests', 'test_input', 'sequences')
-        self.infiles = [os.path.join(self.seqdir, fname) for fname in
-                        os.listdir(self.seqdir)]
+        self.indir = os.path.join("tests", "test_input", "anib")
+        self.outdir = os.path.join("tests", "test_output", "anib")
+        self.seqdir = os.path.join("tests", "test_input", "sequences")
+        self.infiles = [
+            os.path.join(self.seqdir, fname) for fname in os.listdir(self.seqdir)
+        ]
         self.fraglen = 1000
-        self.fmtdboutdir = os.path.join(self.outdir, 'formatdb')
-        self.fmtdbcmd = ' '.join(["formatdb -p F -i",
-                                  "tests/test_output/anib/formatdb/NC_002696.fna",
-                                  "-t NC_002696"])
-        self.makeblastdbdir = os.path.join(self.outdir, 'makeblastdb')
-        self.makeblastdbcmd = ' '.join(["makeblastdb -dbtype nucl -in",
-                                        "tests/test_input/sequences/NC_002696.fna",
-                                        "-title NC_002696 -out",
-                                        os.path.join('tests', 'test_output',
-                                                     'anib', 'makeblastdb',
-                                                     'NC_002696.fna')])
-        self.blastdbfnames = [os.path.join(self.seqdir, fname) for fname in
-                              ('NC_002696.fna', 'NC_010338.fna')]
-        self.blastdbtgt = [(' '.join(['makeblastdb -dbtype nucl -in',
-                                      'tests/test_input/sequences/NC_002696.fna',
-                                      '-title NC_002696 -out',
-                                      'tests/test_output/anib/NC_002696.fna']),
-                            'tests/test_output/anib/NC_002696.fna'),
-                           (' '.join(['makeblastdb -dbtype nucl -in',
-                                      'tests/test_input/sequences/NC_010338.fna',
-                                      '-title NC_010338 -out',
-                                      'tests/test_output/anib/NC_010338.fna']),
-                            'tests/test_output/anib/NC_010338.fna')]
-        self.blastdbtgtlegacy = [(' '.join(['formatdb -p F -i',
-                                            'tests/test_output/anib/NC_002696.fna',
-                                            '-t NC_002696']),
-                                  'tests/test_output/anib/NC_002696.fna'),
-                                 (' '.join(['formatdb -p F -i',
-                                            'tests/test_output/anib/NC_010338.fna',
-                                            '-t NC_010338']),
-                                  'tests/test_output/anib/NC_010338.fna')]
-        self.blastncmd = ' '.join(["blastn -out",
-                                   os.path.join("tests", "test_output", "anib",
-                                                "NC_002696_vs_NC_010338.blast_tab"),
-                                   "-query tests/test_input/sequences/NC_002696.fna",
-                                   "-db tests/test_input/sequences/NC_010338.fna",
-                                   "-xdrop_gap_final 150 -dust no -evalue 1e-15",
-                                   "-max_target_seqs 1 -outfmt '6 qseqid sseqid",
-                                   "length mismatch pident nident qlen slen qstart",
-                                   "qend sstart send positive ppos gaps' -task blastn"])
-        self.blastallcmd = ' '.join(['blastall -p blastn -o',
-                                     os.path.join('tests', 'test_output', 'anib',
-                                                  'NC_002696_vs_NC_010338.blast_tab'),
-                                     '-i tests/test_input/sequences/NC_002696.fna',
-                                     '-d tests/test_input/sequences/NC_010338.fna',
-                                     '-X 150 -q -1 -F F -e 1e-15 -b 1 -v 1 -m 8'])
-        self.blastntgt = [' '.join(["blastn -out",
-                                    os.path.join("tests", "test_output", "anib",
-                                                 "NC_002696_vs_NC_010338.blast_tab"),
-                                    "-query tests/test_input/sequences/NC_002696.fna",
-                                    "-db tests/test_input/sequences/NC_010338.fna",
-                                    "-xdrop_gap_final 150 -dust no -evalue 1e-15",
-                                    "-max_target_seqs 1 -outfmt '6 qseqid sseqid",
-                                    "length mismatch pident nident qlen slen qstart",
-                                    "qend sstart send positive ppos gaps' -task blastn"]),
-                          ' '.join(["blastn -out",
-                                    os.path.join("tests", "test_output", "anib",
-                                                 "NC_010338_vs_NC_002696.blast_tab"),
-                                    "-query tests/test_input/sequences/NC_010338.fna",
-                                    "-db tests/test_input/sequences/NC_002696.fna",
-                                    "-xdrop_gap_final 150 -dust no -evalue 1e-15",
-                                    "-max_target_seqs 1 -outfmt '6 qseqid sseqid length",
-                                    "mismatch pident nident qlen slen qstart qend",
-                                    "sstart send positive ppos gaps' -task blastn"])]
-        self.blastalltgt = [' '.join(['blastall -p blastn -o',
-                                      os.path.join('tests', 'test_output', 'anib',
-                                                   'NC_002696_vs_NC_010338.blast_tab'),
-                                      '-i tests/test_input/sequences/NC_002696.fna',
-                                      '-d tests/test_input/sequences/NC_010338.fna',
-                                      '-X 150 -q -1 -F F -e 1e-15 -b 1 -v 1 -m 8']),
-                            ' '.join(['blastall -p blastn -o',
-                                      os.path.join('tests', 'test_output', 'anib',
-                                                   'NC_010338_vs_NC_002696.blast_tab'),
-                                      '-i tests/test_input/sequences/NC_010338.fna',
-                                      '-d tests/test_input/sequences/NC_002696.fna',
-                                      '-X 150 -q -1 -F F -e 1e-15 -b 1 -v 1 -m 8'])]
+        self.fmtdboutdir = os.path.join(self.outdir, "formatdb")
+        self.fmtdbcmd = " ".join(
+            [
+                "formatdb -p F -i",
+                "tests/test_output/anib/formatdb/NC_002696.fna",
+                "-t NC_002696",
+            ]
+        )
+        self.makeblastdbdir = os.path.join(self.outdir, "makeblastdb")
+        self.makeblastdbcmd = " ".join(
+            [
+                "makeblastdb -dbtype nucl -in",
+                "tests/test_input/sequences/NC_002696.fna",
+                "-title NC_002696 -out",
+                os.path.join(
+                    "tests", "test_output", "anib", "makeblastdb", "NC_002696.fna"
+                ),
+            ]
+        )
+        self.blastdbfnames = [
+            os.path.join(self.seqdir, fname)
+            for fname in ("NC_002696.fna", "NC_010338.fna")
+        ]
+        self.blastdbtgt = [
+            (
+                " ".join(
+                    [
+                        "makeblastdb -dbtype nucl -in",
+                        "tests/test_input/sequences/NC_002696.fna",
+                        "-title NC_002696 -out",
+                        "tests/test_output/anib/NC_002696.fna",
+                    ]
+                ),
+                "tests/test_output/anib/NC_002696.fna",
+            ),
+            (
+                " ".join(
+                    [
+                        "makeblastdb -dbtype nucl -in",
+                        "tests/test_input/sequences/NC_010338.fna",
+                        "-title NC_010338 -out",
+                        "tests/test_output/anib/NC_010338.fna",
+                    ]
+                ),
+                "tests/test_output/anib/NC_010338.fna",
+            ),
+        ]
+        self.blastdbtgtlegacy = [
+            (
+                " ".join(
+                    [
+                        "formatdb -p F -i",
+                        "tests/test_output/anib/NC_002696.fna",
+                        "-t NC_002696",
+                    ]
+                ),
+                "tests/test_output/anib/NC_002696.fna",
+            ),
+            (
+                " ".join(
+                    [
+                        "formatdb -p F -i",
+                        "tests/test_output/anib/NC_010338.fna",
+                        "-t NC_010338",
+                    ]
+                ),
+                "tests/test_output/anib/NC_010338.fna",
+            ),
+        ]
+        self.blastncmd = " ".join(
+            [
+                "blastn -out",
+                os.path.join(
+                    "tests", "test_output", "anib", "NC_002696_vs_NC_010338.blast_tab"
+                ),
+                "-query tests/test_input/sequences/NC_002696.fna",
+                "-db tests/test_input/sequences/NC_010338.fna",
+                "-xdrop_gap_final 150 -dust no -evalue 1e-15",
+                "-max_target_seqs 1 -outfmt '6 qseqid sseqid",
+                "length mismatch pident nident qlen slen qstart",
+                "qend sstart send positive ppos gaps' -task blastn",
+            ]
+        )
+        self.blastallcmd = " ".join(
+            [
+                "blastall -p blastn -o",
+                os.path.join(
+                    "tests", "test_output", "anib", "NC_002696_vs_NC_010338.blast_tab"
+                ),
+                "-i tests/test_input/sequences/NC_002696.fna",
+                "-d tests/test_input/sequences/NC_010338.fna",
+                "-X 150 -q -1 -F F -e 1e-15 -b 1 -v 1 -m 8",
+            ]
+        )
+        self.blastntgt = [
+            " ".join(
+                [
+                    "blastn -out",
+                    os.path.join(
+                        "tests",
+                        "test_output",
+                        "anib",
+                        "NC_002696_vs_NC_010338.blast_tab",
+                    ),
+                    "-query tests/test_input/sequences/NC_002696.fna",
+                    "-db tests/test_input/sequences/NC_010338.fna",
+                    "-xdrop_gap_final 150 -dust no -evalue 1e-15",
+                    "-max_target_seqs 1 -outfmt '6 qseqid sseqid",
+                    "length mismatch pident nident qlen slen qstart",
+                    "qend sstart send positive ppos gaps' -task blastn",
+                ]
+            ),
+            " ".join(
+                [
+                    "blastn -out",
+                    os.path.join(
+                        "tests",
+                        "test_output",
+                        "anib",
+                        "NC_010338_vs_NC_002696.blast_tab",
+                    ),
+                    "-query tests/test_input/sequences/NC_010338.fna",
+                    "-db tests/test_input/sequences/NC_002696.fna",
+                    "-xdrop_gap_final 150 -dust no -evalue 1e-15",
+                    "-max_target_seqs 1 -outfmt '6 qseqid sseqid length",
+                    "mismatch pident nident qlen slen qstart qend",
+                    "sstart send positive ppos gaps' -task blastn",
+                ]
+            ),
+        ]
+        self.blastalltgt = [
+            " ".join(
+                [
+                    "blastall -p blastn -o",
+                    os.path.join(
+                        "tests",
+                        "test_output",
+                        "anib",
+                        "NC_002696_vs_NC_010338.blast_tab",
+                    ),
+                    "-i tests/test_input/sequences/NC_002696.fna",
+                    "-d tests/test_input/sequences/NC_010338.fna",
+                    "-X 150 -q -1 -F F -e 1e-15 -b 1 -v 1 -m 8",
+                ]
+            ),
+            " ".join(
+                [
+                    "blastall -p blastn -o",
+                    os.path.join(
+                        "tests",
+                        "test_output",
+                        "anib",
+                        "NC_010338_vs_NC_002696.blast_tab",
+                    ),
+                    "-i tests/test_input/sequences/NC_010338.fna",
+                    "-d tests/test_input/sequences/NC_002696.fna",
+                    "-X 150 -q -1 -F F -e 1e-15 -b 1 -v 1 -m 8",
+                ]
+            ),
+        ]
         self.blastnjobdict = sorted(
-            [('tests/test_output/anib/NC_002696.fna',
-              'makeblastdb -dbtype nucl ' +
-              '-in tests/test_input/sequences/NC_002696.fna ' +
-              '-title NC_002696 -out tests/test_output/anib/NC_002696.fna'),
-             ('tests/test_output/anib/NC_010338.fna',
-              'makeblastdb -dbtype nucl ' +
-              '-in tests/test_input/sequences/NC_010338.fna ' +
-              '-title NC_010338 -out tests/test_output/anib/NC_010338.fna'),
-             ('tests/test_output/anib/NC_011916.fna',
-              'makeblastdb -dbtype nucl ' +
-              '-in tests/test_input/sequences/NC_011916.fna ' +
-              '-title NC_011916 -out tests/test_output/anib/NC_011916.fna'),
-             ('tests/test_output/anib/NC_014100.fna',
-              'makeblastdb -dbtype nucl ' +
-              '-in tests/test_input/sequences/NC_014100.fna ' +
-              '-title NC_014100 -out tests/test_output/anib/NC_014100.fna')])
+            [
+                (
+                    "tests/test_output/anib/NC_002696.fna",
+                    "makeblastdb -dbtype nucl "
+                    + "-in tests/test_input/sequences/NC_002696.fna "
+                    + "-title NC_002696 -out tests/test_output/anib/NC_002696.fna",
+                ),
+                (
+                    "tests/test_output/anib/NC_010338.fna",
+                    "makeblastdb -dbtype nucl "
+                    + "-in tests/test_input/sequences/NC_010338.fna "
+                    + "-title NC_010338 -out tests/test_output/anib/NC_010338.fna",
+                ),
+                (
+                    "tests/test_output/anib/NC_011916.fna",
+                    "makeblastdb -dbtype nucl "
+                    + "-in tests/test_input/sequences/NC_011916.fna "
+                    + "-title NC_011916 -out tests/test_output/anib/NC_011916.fna",
+                ),
+                (
+                    "tests/test_output/anib/NC_014100.fna",
+                    "makeblastdb -dbtype nucl "
+                    + "-in tests/test_input/sequences/NC_014100.fna "
+                    + "-title NC_014100 -out tests/test_output/anib/NC_014100.fna",
+                ),
+            ]
+        )
         self.blastalljobdict = sorted(
-            [('tests/test_output/anib/NC_002696.fna',
-              'formatdb -p F -i tests/test_output/anib/NC_002696.fna ' +
-              '-t NC_002696'),
-             ('tests/test_output/anib/NC_010338.fna',
-              'formatdb -p F -i tests/test_output/anib/NC_010338.fna ' +
-              '-t NC_010338'),
-             ('tests/test_output/anib/NC_011916.fna',
-              'formatdb -p F -i tests/test_output/anib/NC_011916.fna ' +
-              '-t NC_011916'),
-             ('tests/test_output/anib/NC_014100.fna',
-              'formatdb -p F -i tests/test_output/anib/NC_014100.fna ' +
-              '-t NC_014100')])
+            [
+                (
+                    "tests/test_output/anib/NC_002696.fna",
+                    "formatdb -p F -i tests/test_output/anib/NC_002696.fna "
+                    + "-t NC_002696",
+                ),
+                (
+                    "tests/test_output/anib/NC_010338.fna",
+                    "formatdb -p F -i tests/test_output/anib/NC_010338.fna "
+                    + "-t NC_010338",
+                ),
+                (
+                    "tests/test_output/anib/NC_011916.fna",
+                    "formatdb -p F -i tests/test_output/anib/NC_011916.fna "
+                    + "-t NC_011916",
+                ),
+                (
+                    "tests/test_output/anib/NC_014100.fna",
+                    "formatdb -p F -i tests/test_output/anib/NC_014100.fna "
+                    + "-t NC_014100",
+                ),
+            ]
+        )
         os.makedirs(self.outdir, exist_ok=True)
         os.makedirs(self.fmtdboutdir, exist_ok=True)
         os.makedirs(self.makeblastdbdir, exist_ok=True)
 
+    @nottest  #  legacy BLAST deprecated
     def test_formatdb_generation(self):
         """generate formatdb command-line."""
-        cmd = anib.construct_formatdb_cmd(os.path.join(self.seqdir,
-                                                       "NC_002696.fna"),
-                                          self.fmtdboutdir)
+        cmd = anib.construct_formatdb_cmd(
+            os.path.join(self.seqdir, "NC_002696.fna"), self.fmtdboutdir
+        )
         assert_equal(cmd[0], self.fmtdbcmd)  # correct command
-        assert(os.path.isfile(cmd[1]))       # creates new file
+        assert os.path.isfile(cmd[1])  # creates new file
 
     def test_makeblastdb_generation(self):
         """generate makeblastdb command-line."""
-        cmd = anib.construct_makeblastdb_cmd(os.path.join(self.seqdir,
-                                                          "NC_002696.fna"),
-                                             self.makeblastdbdir)
+        cmd = anib.construct_makeblastdb_cmd(
+            os.path.join(self.seqdir, "NC_002696.fna"), self.makeblastdbdir
+        )
         assert_equal(cmd[0], self.makeblastdbcmd)  # correct command
 
     def test_blastdb_commands(self):
-        """generate both BLAST+ and legacy BLAST db commands."""
+        """generate BLAST+ db commands."""
         # BLAST+
-        cmds = anib.generate_blastdb_commands(self.blastdbfnames, self.outdir,
-                                              mode="ANIb")
+        cmds = anib.generate_blastdb_commands(
+            self.blastdbfnames, self.outdir, mode="ANIb"
+        )
         assert_equal(cmds, self.blastdbtgt)
+
+    @nottest  #  legacy BLAST deprecated
+    def test_legacy_blastdb_commands(self):
+        """generate legacy BLAST db commands."""
         # legacy
-        cmds = anib.generate_blastdb_commands(self.blastdbfnames, self.outdir,
-                                              mode="ANIblastall")
+        cmds = anib.generate_blastdb_commands(
+            self.blastdbfnames, self.outdir, mode="ANIblastall"
+        )
         assert_equal(cmds, self.blastdbtgtlegacy)
 
     def test_blastn_generation(self):
         """generate BLASTN+ command-line."""
-        cmd = anib.construct_blastn_cmdline(self.blastdbfnames[0],
-                                            self.blastdbfnames[1],
-                                            self.outdir)
+        cmd = anib.construct_blastn_cmdline(
+            self.blastdbfnames[0], self.blastdbfnames[1], self.outdir
+        )
         assert_equal(cmd, self.blastncmd)
 
+    @nottest  #  legacy BLAST deprecated
     def test_blastall_generation(self):
         """generate legacy BLASTN command-line."""
-        cmd = anib.construct_blastall_cmdline(self.blastdbfnames[0],
-                                              self.blastdbfnames[1],
-                                              self.outdir)
+        cmd = anib.construct_blastall_cmdline(
+            self.blastdbfnames[0], self.blastdbfnames[1], self.outdir
+        )
         assert_equal(cmd, self.blastallcmd)
 
     def test_blastn_commands(self):
-        """generate both BLASTN+ and legacy BLASTN commands."""
+        """generate BLASTN+ commands."""
         # BLAST+
-        cmds = anib.generate_blastn_commands(self.blastdbfnames, self.outdir,
-                                             mode="ANIb")
+        cmds = anib.generate_blastn_commands(
+            self.blastdbfnames, self.outdir, mode="ANIb"
+        )
         assert_equal(cmds, self.blastntgt)
-        cmds = anib.generate_blastn_commands(self.blastdbfnames, self.outdir,
-                                             mode="ANIblastall")
+
+    @nottest  #  legacy BLAST deprecated
+    def test_legacy_blastn_commands(self):
+        """generate legacy BLASTN commands."""
+        cmds = anib.generate_blastn_commands(
+            self.blastdbfnames, self.outdir, mode="ANIblastall"
+        )
         assert_equal(cmds, self.blastalltgt)
 
+    @nottest  #  legacy BLAST deprecated
     def test_blastall_dbjobdict(self):
         """generate dictionary of legacy BLASTN database jobs."""
         blastcmds = anib.make_blastcmd_builder("ANIblastall", self.outdir)
         jobdict = anib.build_db_jobs(self.infiles, blastcmds)
-        assert_equal(sorted([(k, v.script) for (k, v) in jobdict.items()]),
-                     self.blastalljobdict)
+        assert_equal(
+            sorted([(k, v.script) for (k, v) in jobdict.items()]), self.blastalljobdict
+        )
 
     def test_blastn_dbjobdict(self):
         """generate dictionary of BLASTN+ database jobs."""
         blastcmds = anib.make_blastcmd_builder("ANIb", self.outdir)
         jobdict = anib.build_db_jobs(self.infiles, blastcmds)
-        assert_equal(sorted([(k, v.script) for (k, v) in jobdict.items()]),
-                     self.blastnjobdict)
+        assert_equal(
+            sorted([(k, v.script) for (k, v) in jobdict.items()]), self.blastnjobdict
+        )
 
     def test_blastn_graph(self):
-        """create jobgraph for BLASTN jobs."""
-        fragresult = anib.fragment_fasta_files(self.infiles, self.outdir,
-                                               self.fraglen)
+        """create jobgraph for BLASTN+ jobs."""
+        fragresult = anib.fragment_fasta_files(self.infiles, self.outdir, self.fraglen)
         blastcmds = anib.make_blastcmd_builder("ANIb", self.outdir)
-        jobgraph = anib.make_job_graph(self.infiles, fragresult[0],
-                                       blastcmds)
+        jobgraph = anib.make_job_graph(self.infiles, fragresult[0], blastcmds)
         # We check that the main script job is a blastn job, and that there
         # is a single dependency, which is a makeblastdb job
         for job in jobgraph:
-            assert(job.script.startswith('blastn'))
+            assert job.script.startswith("blastn")
             assert_equal(1, len(job.dependencies))
             dep = job.dependencies[0]
-            assert(dep.script.startswith('makeblastdb'))
+            assert dep.script.startswith("makeblastdb")
 
+    @nottest  #  legacy BLAST deprecated
     def test_blastall_graph(self):
         """create jobgraph for legacy BLASTN jobs."""
-        fragresult = anib.fragment_fasta_files(self.infiles, self.outdir,
-                                               self.fraglen)
+        fragresult = anib.fragment_fasta_files(self.infiles, self.outdir, self.fraglen)
         blastcmds = anib.make_blastcmd_builder("ANIblastall", self.outdir)
-        jobgraph = anib.make_job_graph(self.infiles, fragresult[0],
-                                       blastcmds)
+        jobgraph = anib.make_job_graph(self.infiles, fragresult[0], blastcmds)
         # We check that the main script job is a blastn job, and that there
         # is a single dependency, which is a makeblastdb job
         for job in jobgraph:
-            assert(job.script.startswith('blastall -p blastn'))
+            assert job.script.startswith("blastall -p blastn")
             assert_equal(1, len(job.dependencies))
             dep = job.dependencies[0]
-            assert(dep.script.startswith('formatdb'))
+            assert dep.script.startswith("formatdb")
 
 
 class TestFragments(unittest.TestCase):
@@ -284,21 +405,32 @@ class TestFragments(unittest.TestCase):
 
     def setUp(self):
         """Initialise parameters for tests."""
-        self.outdir = os.path.join('tests', 'test_output', 'anib')
-        self.seqdir = os.path.join('tests', 'test_input', 'sequences')
-        self.infnames = [os.path.join(self.seqdir, fname) for fname in
-                         ('NC_002696.fna', 'NC_010338.fna',
-                          'NC_011916.fna', 'NC_014100.fna')]
-        self.outfnames = [os.path.join(self.outdir, fname) for fname in
-                          ('NC_002696-fragments.fna', 'NC_010338-fragments.fna',
-                           'NC_011916-fragments.fna', 'NC_014100-fragments.fna')]
+        self.outdir = os.path.join("tests", "test_output", "anib")
+        self.seqdir = os.path.join("tests", "test_input", "sequences")
+        self.infnames = [
+            os.path.join(self.seqdir, fname)
+            for fname in (
+                "NC_002696.fna",
+                "NC_010338.fna",
+                "NC_011916.fna",
+                "NC_014100.fna",
+            )
+        ]
+        self.outfnames = [
+            os.path.join(self.outdir, fname)
+            for fname in (
+                "NC_002696-fragments.fna",
+                "NC_010338-fragments.fna",
+                "NC_011916-fragments.fna",
+                "NC_014100-fragments.fna",
+            )
+        ]
         self.fraglen = 1000
         os.makedirs(self.outdir, exist_ok=True)
 
     def test_fragment_files(self):
         """fragment files for ANIb/ANIblastall."""
-        result = anib.fragment_fasta_files(self.infnames, self.outdir,
-                                           self.fraglen)
+        result = anib.fragment_fasta_files(self.infnames, self.outdir, self.fraglen)
         # Are files created?
         for outfname in self.outfnames:
             assert os.path.isfile(outfname)
@@ -314,51 +446,65 @@ class TestParsing(unittest.TestCase):
     """Class defining tests of BLAST output parsing."""
 
     def setUp(self):
-        self.indir = os.path.join('tests', 'test_input', 'anib')
-        self.seqdir = os.path.join('tests', 'test_input', 'sequences')
-        self.fragdir = os.path.join('tests', 'test_input', 'anib', 'fragfiles')
-        self.anibdir = os.path.join('tests', 'test_input', 'anib', 'blastn')
-        self.aniblastalldir = os.path.join('tests', 'test_input', 'anib', 'blastall')
-        self.fname_legacy = os.path.join(self.indir,
-                                         "NC_002696_vs_NC_010338.blast_tab")
-        self.fname = os.path.join(self.indir,
-                                  "NC_002696_vs_NC_011916.blast_tab")
-        self.fragfname = os.path.join(self.indir,
-                                      "NC_002696-fragments.fna")
+        self.indir = os.path.join("tests", "test_input", "anib")
+        self.seqdir = os.path.join("tests", "test_input", "sequences")
+        self.fragdir = os.path.join("tests", "test_input", "anib", "fragfiles")
+        self.anibdir = os.path.join("tests", "test_input", "anib", "blastn")
+        self.aniblastalldir = os.path.join("tests", "test_input", "anib", "blastall")
+        self.fname_legacy = os.path.join(self.indir, "NC_002696_vs_NC_010338.blast_tab")
+        self.fname = os.path.join(self.indir, "NC_002696_vs_NC_011916.blast_tab")
+        self.fragfname = os.path.join(self.indir, "NC_002696-fragments.fna")
         self.fraglens = 1000
-        self.infnames = [os.path.join(self.seqdir, fname) for fname in
-                         ('NC_002696.fna', 'NC_010338.fna',
-                          'NC_011916.fna', 'NC_014100.fna')]
-        self.fragfiles = [os.path.join(self.fragdir, fname) for fname in
-                          ('NC_002696-fragments.fna', 'NC_010338-fragments.fna',
-                           'NC_011916-fragments.fna', 'NC_014100-fragments.fna')]
-        self.anibtgt = pd.DataFrame([[1.000000, 0.796974, 0.999977, 0.837285],
-                                     [0.795958, 1.000000, 0.795917, 0.798250],
-                                     [0.999922, 0.795392, 1.000000, 0.837633],
-                                     [0.836780, 0.798704, 0.836823, 1.000000]],
-                                    columns=['NC_002696', 'NC_010338',
-                                             'NC_011916', 'NC_014100'],
-                                    index=['NC_002696', 'NC_010338', 'NC_011916',
-                                           'NC_014100'])
-        self.aniblastalltgt = pd.DataFrame([[1.000000, 0.785790, 0.999977, 0.830641],
-                                            [0.781319, 1.000000, 0.781281, 0.782723],
-                                            [0.999937, 0.782968, 1.000000, 0.830431],
-                                            [0.828919, 0.784533, 0.828853, 1.000000]],
-                                           columns=['NC_002696', 'NC_010338',
-                                                    'NC_011916', 'NC_014100'],
-                                           index=['NC_002696', 'NC_010338', 'NC_011916',
-                                                  'NC_014100'])
+        self.infnames = [
+            os.path.join(self.seqdir, fname)
+            for fname in (
+                "NC_002696.fna",
+                "NC_010338.fna",
+                "NC_011916.fna",
+                "NC_014100.fna",
+            )
+        ]
+        self.fragfiles = [
+            os.path.join(self.fragdir, fname)
+            for fname in (
+                "NC_002696-fragments.fna",
+                "NC_010338-fragments.fna",
+                "NC_011916-fragments.fna",
+                "NC_014100-fragments.fna",
+            )
+        ]
+        self.anibtgt = pd.DataFrame(
+            [
+                [1.000000, 0.796974, 0.999977, 0.837285],
+                [0.795958, 1.000000, 0.795917, 0.798250],
+                [0.999922, 0.795392, 1.000000, 0.837633],
+                [0.836780, 0.798704, 0.836823, 1.000000],
+            ],
+            columns=["NC_002696", "NC_010338", "NC_011916", "NC_014100"],
+            index=["NC_002696", "NC_010338", "NC_011916", "NC_014100"],
+        )
+        self.aniblastalltgt = pd.DataFrame(
+            [
+                [1.000000, 0.785790, 0.999977, 0.830641],
+                [0.781319, 1.000000, 0.781281, 0.782723],
+                [0.999937, 0.782968, 1.000000, 0.830431],
+                [0.828919, 0.784533, 0.828853, 1.000000],
+            ],
+            columns=["NC_002696", "NC_010338", "NC_011916", "NC_014100"],
+            index=["NC_002696", "NC_010338", "NC_011916", "NC_014100"],
+        )
 
+    @nottest  # legacy BLASTN deprecated
     def test_parse_blasttab(self):
         """parses ANIblastall .blast_tab output."""
         fragdata = anib.get_fraglength_dict([self.fragfname])
         # ANIb output
-        result = anib.parse_blast_tab(self.fname, fragdata, 0.3, 0.7,
-                                      mode="ANIb")
+        result = anib.parse_blast_tab(self.fname, fragdata, 0.3, 0.7, mode="ANIb")
         assert_equal(result, (4016551, 93, 99.997693577050029))
         # ANIblastall output
-        result = anib.parse_blast_tab(self.fname_legacy, fragdata,
-                                      0.3, 0.7, mode="ANIblastall")
+        result = anib.parse_blast_tab(
+            self.fname_legacy, fragdata, 0.3, 0.7, mode="ANIblastall"
+        )
         assert_equal(result, (1966922, 406104, 78.578978313253018))
 
     def test_blastdir_processing(self):
@@ -366,12 +512,22 @@ class TestParsing(unittest.TestCase):
         orglengths = pyani_files.get_sequence_lengths(self.infnames)
         fraglengths = anib.get_fraglength_dict(self.fragfiles)
         # ANIb
-        result = anib.process_blast(self.anibdir, orglengths,
-                                    fraglengths, mode="ANIb")
-        assert_frame_equal(result.percentage_identity.sort_index(1).sort_index(),
-                           self.anibtgt.sort_index(1).sort_index())
+        result = anib.process_blast(self.anibdir, orglengths, fraglengths, mode="ANIb")
+        assert_frame_equal(
+            result.percentage_identity.sort_index(1).sort_index(),
+            self.anibtgt.sort_index(1).sort_index(),
+        )
+
+    @nottest  #  legacy BLAST deprecated
+    def test_legacy_blastdir_processing(self):
+        """parse directory of legacy .blast_tab output"""
+        orglengths = pyani_files.get_sequence_lengths(self.infnames)
+        fraglengths = anib.get_fraglength_dict(self.fragfiles)
         # ANIblastall
-        result = anib.process_blast(self.aniblastalldir, orglengths,
-                                    fraglengths, mode="ANIblastall")
-        assert_frame_equal(result.percentage_identity.sort_index(1).sort_index(),
-                           self.aniblastalltgt.sort_index(1).sort_index())
+        result = anib.process_blast(
+            self.aniblastalldir, orglengths, fraglengths, mode="ANIblastall"
+        )
+        assert_frame_equal(
+            result.percentage_identity.sort_index(1).sort_index(),
+            self.aniblastalltgt.sort_index(1).sort_index(),
+        )

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -11,7 +11,8 @@ These tests are intended to be run using the nose package
 import subprocess
 import sys
 
-from nose.tools import assert_equal
+from nose.tools import assert_equal, nottest
+
 
 def test_import_biopython():
     """Test Biopython import."""
@@ -41,31 +42,41 @@ def test_import_scipy():
 def test_run_blast():
     """Test that BLAST+ is runnable."""
     cmd = "blastn -version"
-    result = subprocess.run(cmd, shell=sys.platform != "win32",
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE,
-                            check=True)
+    result = subprocess.run(
+        cmd,
+        shell=sys.platform != "win32",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
     print(result.stdout)
-    assert_equal(result.stdout[:6], b'blastn')
+    assert_equal(result.stdout[:6], b"blastn")
 
 
+@nottest
 def test_run_blastall():
     """Test that legacy BLAST is runnable."""
     cmd = "blastall"
     # Can't use check=True, as blastall without arguments returns 1!
-    result = subprocess.run(cmd, shell=sys.platform != "win32",
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
+    result = subprocess.run(
+        cmd,
+        shell=sys.platform != "win32",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
     print(result.stdout)
-    assert_equal(result.stdout[1:9], b'blastall')
+    assert_equal(result.stdout[1:9], b"blastall")
 
 
 def test_run_nucmer():
     """Test that NUCmer is runnable."""
     cmd = "nucmer --version"
-    result = subprocess.run(cmd, shell=sys.platform != "win32",
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE,
-                            check=True)
+    result = subprocess.run(
+        cmd,
+        shell=sys.platform != "win32",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
     print(result.stderr)  # NUCmer puts output to STDERR!
-    assert_equal(result.stderr[:6], b'nucmer')
+    assert_equal(result.stderr[:6], b"nucmer")

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -54,9 +54,9 @@ THE SOFTWARE.
 import os
 import unittest
 
-from nose.tools import (assert_equal, )
+from nose.tools import assert_equal, nottest
 
-from pyani import (run_multiprocessing, pyani_jobs, anib)
+from pyani import run_multiprocessing, pyani_jobs, anib
 
 
 class TestMultiprocessing(unittest.TestCase):
@@ -65,14 +65,17 @@ class TestMultiprocessing(unittest.TestCase):
 
     def setUp(self):
         """Define parameters and arguments for tests."""
-        self.cmdlist = ['for i in %s; do echo "Thread %d: value ${i}"; done' %
-                        (' '.join([str(e) for e in range(v)]), v) for
-                        v in range(5)]
-        self.cmds = ['ls -ltrh', 'echo ${PWD}']
-        self.seqdir = os.path.join('tests', 'test_input', 'sequences')
-        self.outdir = os.path.join('tests', 'test_output', 'multiprocessing')
-        self.infiles = [os.path.join(self.seqdir, fname) for fname in
-                        os.listdir(self.seqdir)][:2]
+        self.cmdlist = [
+            'for i in %s; do echo "Thread %d: value ${i}"; done'
+            % (" ".join([str(e) for e in range(v)]), v)
+            for v in range(5)
+        ]
+        self.cmds = ["ls -ltrh", "echo ${PWD}"]
+        self.seqdir = os.path.join("tests", "test_input", "sequences")
+        self.outdir = os.path.join("tests", "test_output", "multiprocessing")
+        self.infiles = [
+            os.path.join(self.seqdir, fname) for fname in os.listdir(self.seqdir)
+        ][:2]
         self.fraglen = 1000
         os.makedirs(self.outdir, exist_ok=True)
 
@@ -83,8 +86,8 @@ class TestMultiprocessing(unittest.TestCase):
 
     def test_cmdsets(self):
         """module builds command sets."""
-        job1 = pyani_jobs.Job('dummy_with_dependency', self.cmds[0])
-        job2 = pyani_jobs.Job('dummy_dependency', self.cmds[1])
+        job1 = pyani_jobs.Job("dummy_with_dependency", self.cmds[0])
+        job2 = pyani_jobs.Job("dummy_dependency", self.cmds[1])
         job1.add_dependency(job2)
         cmdsets = run_multiprocessing.populate_cmdsets(job1, list(), depth=1)
         target = [{cmd} for cmd in self.cmds]
@@ -92,10 +95,8 @@ class TestMultiprocessing(unittest.TestCase):
 
     def test_dependency_graph_run(self):
         """module runs dependency graph."""
-        fragresult = anib.fragment_fasta_files(self.infiles, self.outdir,
-                                               self.fraglen)
-        blastcmds = anib.make_blastcmd_builder("ANIblastall", self.outdir)
-        jobgraph = anib.make_job_graph(self.infiles, fragresult[0],
-                                       blastcmds)
+        fragresult = anib.fragment_fasta_files(self.infiles, self.outdir, self.fraglen)
+        blastcmds = anib.make_blastcmd_builder("ANIb", self.outdir)
+        jobgraph = anib.make_job_graph(self.infiles, fragresult[0], blastcmds)
         result = run_multiprocessing.run_dependency_graph(jobgraph)
         assert_equal(0, result)


### PR DESCRIPTION
The legacy BLAST executables are no longer available from NCBI's FTP site, and they cannot be integrated into Travis CI for testing. Therefore all testing for ANIblastall is now skipped.

In addition, we add Python 3.7 test support to TravisCI.