### PR TITLE
Add mypy type hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ distribute*
 docs/_build/
 docs/make.bat
 
+# MyPy cache
+.mypy_cache/
+
 # Test output
 *.log
 tests/test_*_out/

--- a/pyani/anib.py
+++ b/pyani/anib.py
@@ -90,9 +90,9 @@ from logging import Logger
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple
 
-import pandas as pd
+import pandas as pd  # type: ignore
 
-from Bio import SeqIO
+from Bio import SeqIO  # type: ignore
 
 from . import pyani_config
 from . import pyani_files

--- a/pyani/anib.py
+++ b/pyani/anib.py
@@ -81,13 +81,14 @@ qualifying matches contribute to the total aligned length, and total
 aligned sequence identity used to calculate ANI.
 """
 
-import os
 import platform
 import re
 import shutil
 import subprocess
 
+from logging import Logger
 from pathlib import Path
+from typing import Callable, Dict, List, Optional, Tuple
 
 import pandas as pd
 
@@ -99,7 +100,7 @@ from . import pyani_jobs
 from .pyani_tools import ANIResults, BLASTcmds, BLASTexes, BLASTfunctions
 
 
-def get_version(blast_exe=pyani_config.BLASTN_DEFAULT):
+def get_version(blast_exe: Path = pyani_config.BLASTN_DEFAULT) -> str:
     """Return BLAST+ blastn version as a string.
 
     :param blast_exe:  path to blastn executable
@@ -116,16 +117,18 @@ def get_version(blast_exe=pyani_config.BLASTN_DEFAULT):
     """
     cmdline = [blast_exe, "-version"]
     result = subprocess.run(
-        cmdline, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True
+        cmdline, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True  # type: ignore
     )
-    version = re.search(
+    version = re.search(  # type: ignore
         r"(?<=blastn:\s)[0-9\.]*\+", str(result.stdout, "utf-8")
     ).group()
     return f"{platform.system()}_{version}"
 
 
 # Divide input FASTA sequences into fragments
-def fragment_fasta_files(infiles, outdirname, fragsize):
+def fragment_fasta_files(
+    infiles: List[Path], outdirname: Path, fragsize: int
+) -> Tuple[List, Dict]:
     """Chop sequences of the passed files into fragments, return filenames.
 
     :param infiles:  collection of paths to each input sequence file
@@ -166,7 +169,7 @@ def fragment_fasta_files(infiles, outdirname, fragsize):
 
 
 # Get lengths of all sequences in all files
-def get_fraglength_dict(fastafiles):
+def get_fraglength_dict(fastafiles: List[Path]) -> Dict:
     """Return dictionary of sequence fragment lengths, keyed by query name.
 
     :param fastafiles:  list of paths to FASTA input whole sequence files
@@ -183,7 +186,7 @@ def get_fraglength_dict(fastafiles):
 
 
 # Get lengths of all sequences in a file
-def get_fragment_lengths(fastafile):
+def get_fragment_lengths(fastafile: Path) -> Dict:
     """Return dictionary of sequence fragment lengths, keyed by fragment ID.
 
     :param fastafile:
@@ -200,7 +203,7 @@ def get_fragment_lengths(fastafile):
 
 
 # Create dictionary of database building commands, keyed by dbname
-def build_db_jobs(infiles, blastcmds):
+def build_db_jobs(infiles: List[Path], blastcmds: BLASTcmds) -> Dict:
     """Return dictionary of db-building commands, keyed by dbname.
 
     :param infiles:
@@ -217,8 +220,12 @@ def build_db_jobs(infiles, blastcmds):
 
 
 def make_blastcmd_builder(
-    mode, outdir, format_exe=None, blast_exe=None, prefix="ANIBLAST"
-):
+    mode: str,
+    outdir: Path,
+    format_exe: Optional[Path] = None,
+    blast_exe: Optional[Path] = None,
+    prefix: str = "ANIBLAST",
+) -> BLASTcmds:
     """Return BLASTcmds object for construction of BLAST commands.
 
     :param mode:  str, the kind of ANIb analysis (ANIb or ANIblastall)
@@ -251,7 +258,9 @@ def make_blastcmd_builder(
 
 
 # Make a dependency graph of BLAST commands
-def make_job_graph(infiles, fragfiles, blastcmds):
+def make_job_graph(
+    infiles: List[Path], fragfiles: List[Path], blastcmds: BLASTcmds
+) -> List[pyani_jobs.Job]:
     """Return job dependency graph, based on the passed input sequence files.
 
     :param infiles:  list of paths to input FASTA files
@@ -304,7 +313,12 @@ def make_job_graph(infiles, fragfiles, blastcmds):
 
 
 # Generate list of makeblastdb command lines from passed filenames
-def generate_blastdb_commands(filenames, outdir, blastdb_exe=None, mode="ANIb"):
+def generate_blastdb_commands(
+    filenames: List[Path],
+    outdir: Path,
+    blastdb_exe: Optional[Path] = None,
+    mode: str = "ANIb",
+) -> List[Tuple[str, Path]]:
     """Return list of makeblastdb command-lines for ANIb/ANIblastall.
 
     :param filenames:  a list of paths to input FASTA files
@@ -328,8 +342,8 @@ def generate_blastdb_commands(filenames, outdir, blastdb_exe=None, mode="ANIb"):
 
 # Generate single makeblastdb command line
 def construct_makeblastdb_cmd(
-    filename, outdir, blastdb_exe=pyani_config.MAKEBLASTDB_DEFAULT
-):
+    filename: Path, outdir: Path, blastdb_exe: Path = pyani_config.MAKEBLASTDB_DEFAULT
+) -> Tuple[str, Path]:
     """Return makeblastdb command and path to output file.
 
     :param filename:  Path, input filename
@@ -344,12 +358,14 @@ def construct_makeblastdb_cmd(
 
 
 # Generate single makeblastdb command line
-def construct_formatdb_cmd(filename, outdir, blastdb_exe=pyani_config.FORMATDB_DEFAULT):
+def construct_formatdb_cmd(
+    filename: Path, outdir: Path, blastdb_exe: Path = pyani_config.FORMATDB_DEFAULT
+) -> Tuple[str, Path]:
     """Return formatdb command and path to output file.
 
-    :param filename:  str, input filename
-    :param outdir:  str, path to output directory
-    :param blastdb_exe:  str, path to the formatdb executable
+    :param filename:  Path, input filename
+    :param outdir:  Path, path to output directory
+    :param blastdb_exe:  Path, path to the formatdb executable
     """
     newfilename = outdir / filename.name
     shutil.copy(filename, newfilename)
@@ -357,7 +373,12 @@ def construct_formatdb_cmd(filename, outdir, blastdb_exe=pyani_config.FORMATDB_D
 
 
 # Generate list of BLASTN command lines from passed filenames
-def generate_blastn_commands(filenames, outdir, blast_exe=None, mode="ANIb"):
+def generate_blastn_commands(
+    filenames: List[Path],
+    outdir: Path,
+    blast_exe: Optional[Path] = None,
+    mode: str = "ANIb",
+) -> List[str]:
     """Return a list of blastn command-lines for ANIm.
 
     :param filenames:  a list of paths to fragmented input FASTA files
@@ -371,7 +392,7 @@ def generate_blastn_commands(filenames, outdir, blast_exe=None, mode="ANIb"):
     fragment_FASTA_files() function above.
     """
     if mode == "ANIb":
-        construct_blast_cmdline = construct_blastn_cmdline
+        construct_blast_cmdline = construct_blastn_cmdline  # type: Callable
     else:
         construct_blast_cmdline = construct_blastall_cmdline
     cmdlines = []
@@ -394,8 +415,11 @@ def generate_blastn_commands(filenames, outdir, blast_exe=None, mode="ANIb"):
 
 # Generate single BLASTN command line
 def construct_blastn_cmdline(
-    fname1, fname2, outdir, blastn_exe=pyani_config.BLASTN_DEFAULT
-):
+    fname1: Path,
+    fname2: Path,
+    outdir: Path,
+    blastn_exe: Path = pyani_config.BLASTN_DEFAULT,
+) -> str:
     """Return a single blastn command.
 
     :param fname1:
@@ -415,8 +439,11 @@ def construct_blastn_cmdline(
 
 # Generate single BLASTALL command line
 def construct_blastall_cmdline(
-    fname1, fname2, outdir, blastall_exe=pyani_config.BLASTALL_DEFAULT
-):
+    fname1: Path,
+    fname2: Path,
+    outdir: Path,
+    blastall_exe: Path = pyani_config.BLASTALL_DEFAULT,
+) -> str:
     """Return single blastall command.
 
     :param fname1:
@@ -432,13 +459,19 @@ def construct_blastall_cmdline(
 
 
 # Process pairwise BLASTN output
-def process_blast(blast_dir, org_lengths, fraglengths=None, mode="ANIb", logger=None):
+def process_blast(
+    blast_dir: Path,
+    org_lengths: Dict,
+    fraglengths: Dict,
+    mode: str = "ANIb",
+    logger: Optional[Logger] = None,
+) -> ANIResults:
     """Return tuple of ANIb results for .blast_tab files in the output dir.
 
-    :param blast_dir:  str, path to the directory containing .blast_tab files
-    :param org_lengths:  str, the base count for each input sequence
+    :param blast_dir:  Path, path to the directory containing .blast_tab files
+    :param org_lengths:  Dict, the base count for each input sequence
     :param fraglengths:  dictionary of query sequence fragment lengths, only
-    needed for BLASTALL output
+        needed for BLASTALL output
     :param mode:  str, analysis type (ANIb or ANIblastall)
     :param logger:  a logger for messages
 
@@ -497,11 +530,14 @@ def process_blast(blast_dir, org_lengths, fraglengths=None, mode="ANIb", logger=
 
 
 # Parse BLASTALL output to get total alignment length and mismatches
-def parse_blast_tab(filename, fraglengths, mode="ANIb"):
+def parse_blast_tab(
+    filename: Path, fraglengths: Dict, mode: str = "ANIb"
+) -> Tuple[int, int, int]:
     """Return (alignment length, similarity errors, mean_pid) tuple.
 
-    :param filename:  str, path to .blast_tab file
-    :param fraglengths:
+    :param filename:  Path, path to .blast_tab file
+    :param fraglengths:  Optional[Dict], dictionary of fragment lengths for each
+        genome.
     :param mode:  str, analysis type (ANIb or ANIblastall)
 
     Calculate the alignment length and total number of similarity errors (as

--- a/pyani/anib.py
+++ b/pyani/anib.py
@@ -117,7 +117,11 @@ def get_version(blast_exe: Path = pyani_config.BLASTN_DEFAULT) -> str:
     """
     cmdline = [blast_exe, "-version"]
     result = subprocess.run(
-        cmdline, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True  # type: ignore
+        cmdline,  # type: ignore
+        shell=False,
+        stdout=subprocess.PIPE,  # type: ignore
+        stderr=subprocess.PIPE,
+        check=True,
     )
     version = re.search(  # type: ignore
         r"(?<=blastn:\s)[0-9\.]*\+", str(result.stdout, "utf-8")
@@ -505,15 +509,17 @@ def process_blast(
         if qname not in list(org_lengths.keys()):
             if logger:
                 logger.warning(
-                    "Query name %s not in input " % qname
-                    + "sequence list, skipping %s" % blastfile
+                    "Query name %s not in input sequence list, skipping %s",
+                    qname,
+                    blastfile,
                 )
             continue
         if sname not in list(org_lengths.keys()):
             if logger:
                 logger.warning(
-                    "Subject name %s not in input " % sname
-                    + "sequence list, skipping %s" % blastfile
+                    "Subject name %s not in input sequence list, skipping %s",
+                    sname,
+                    blastfile,
                 )
             continue
         resultvals = parse_blast_tab(blastfile, fraglengths, mode)

--- a/pyani/anim.py
+++ b/pyani/anim.py
@@ -218,7 +218,10 @@ def construct_nucmer_cmdline(
     # to the outprefix files, as using path.with_suffix() instead can replace part of the filestem
     # in those cases where there is a period in the stem (this occurs frequently as it is part
     # of the NCBI notation for genome assembly versions)
-    filtercmd = f"delta_filter_wrapper.py {filter_exe} -1 {str(outprefix) + '.delta'} {str(outprefix) + '.filter'}"
+    filtercmd = (
+        f"delta_filter_wrapper.py {filter_exe} -1 {str(outprefix) + '.delta'} "
+        f"{str(outprefix) + '.filter'}"
+    )
     return (nucmercmd, filtercmd)
 
 

--- a/pyani/blast.py
+++ b/pyani/blast.py
@@ -38,11 +38,13 @@
 # THE SOFTWARE.
 """Code for handling BLAST output files."""
 
+from typing import Any, List, TextIO
 
-def parse_blasttab(fhandle):
+
+def parse_blasttab(fhandle: TextIO) -> List[List[str]]:
     """Return the passed BLAST tab output file as a list of lists.
 
-    :param fhandle:  filehandle, contains BLAST output file
+    :param fhandle:  TextIO, filehandle containing BLAST output file
 
     This is used when testing for conserved BLAST output, as the
     exact format of the BLAST result can depend on the software version.
@@ -55,7 +57,8 @@ def parse_blasttab(fhandle):
     """
     retval = []
     for line in fhandle.readlines():
-        splitline = line.split("\t")
+        splitline = line.split("\t")  # type: List[Any]
         data = splitline[:2]  # First two columns are strings
         data += [float(_) for _ in splitline[2:]]  # The rest are numeric
+        retval.append(data)
     return retval

--- a/pyani/download.py
+++ b/pyani/download.py
@@ -50,9 +50,9 @@ from collections import namedtuple
 from pathlib import Path
 from urllib.error import HTTPError, URLError
 
-from Bio import Entrez
-from tqdm import tqdm
-from namedlist import namedlist
+from Bio import Entrez  # type: ignore
+from tqdm import tqdm  # type: ignore
+from namedlist import namedlist  # type: ignore
 
 
 # Regular expression for NCBI taxon numbers

--- a/pyani/download.py
+++ b/pyani/download.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # (c) The James Hutton Institute 2016-2019
-# (c) University of Strathclyde 2019
+# (c) University of Strathclyde 2019-2020
 # Author: Leighton Pritchard
 #
 # Contact:
@@ -17,7 +17,7 @@
 # The MIT License
 #
 # Copyright (c) 2016-2019 The James Hutton Institute
-# Copyright (c) 2019 University of Strathclyde
+# Copyright (c) 2019-2020 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -337,13 +337,12 @@ def compile_url(filestem: str, suffix: str, ftpstem: str) -> Tuple[str, str]:
 
 # Download a remote file to the specified directory
 def download_url(
-    url: str, outfname: Path, timeout: int, disable_tqdm: bool = False
+    url: str, outfname: Path, disable_tqdm: bool = False
 ) -> None:
     """Download remote URL to a local directory.
 
-    :param url:
+    :param url:  URL of remote file for download
     :param outfname: Path, path to write output
-    :param timeout:
     :param disable_tqdm:  Boolean, show tqdm progress bar?
 
     This function downloads the contents of the passed URL to the passed
@@ -480,7 +479,10 @@ def create_labels(
     (label/class is unique by a combination of hash and run ID).
     """
     return (
-        f"{genomehash}\t{filestem}_genomic\t{classification.genus[0] + '.'} {classification.species} {classification.strain}",
+        (
+            f"{genomehash}\t{filestem}_genomic\t{classification.genus[0] + '.'} "
+            f"{classification.species} {classification.strain}"
+        ),
         f"{genomehash}\t{filestem}_genomic\t{classification.organism}",
     )
 

--- a/pyani/download.py
+++ b/pyani/download.py
@@ -48,6 +48,7 @@ import urllib.request
 
 from collections import namedtuple
 from pathlib import Path
+from typing import Any, List
 from urllib.error import HTTPError, URLError
 
 from Bio import Entrez  # type: ignore
@@ -78,13 +79,13 @@ class FileExistsException(Exception):
         Exception.__init__(self, msg)
 
 
-def last_exception():
+def last_exception() -> str:
     """Return last exception as a string."""
     exc_type, exc_value, exc_traceback = sys.exc_info()
     return "".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
 
 
-def set_ncbi_email(email):
+def set_ncbi_email(email: str) -> None:
     """Set contact email for NCBI.
 
     :param email:  str, email address to give to Entrez at NCBI
@@ -93,7 +94,7 @@ def set_ncbi_email(email):
     Entrez.tool = "pyani.py"
 
 
-def parse_api_key(api_path):
+def parse_api_key(api_path: Path) -> str:
     """Parse the contents of the file for NCBI API key.
 
     :param api_path:  Path, location of NCBI API key
@@ -107,7 +108,9 @@ def parse_api_key(api_path):
 
 
 # Get results from NCBI web history, in batches
-def entrez_batch_webhistory(record, expected, batchsize, retries, *fnargs, **fnkwargs):
+def entrez_batch_webhistory(
+    record, expected, batchsize, retries, *fnargs, **fnkwargs
+) -> List[str]:
     """Recover the Entrez data from a prior NCBI webhistory search.
 
     :param record:  Entrez webhistory record
@@ -120,7 +123,7 @@ def entrez_batch_webhistory(record, expected, batchsize, retries, *fnargs, **fnk
     Recovers results in batches of defined size, using Efetch.
     Returns all results as a list.
     """
-    results = []
+    results = []  # type: List[Any]
     for start in range(0, expected, batchsize):
         batch_handle = entrez_retry(
             Entrez.efetch,

--- a/pyani/download.py
+++ b/pyani/download.py
@@ -17,7 +17,7 @@
 # The MIT License
 #
 # Copyright (c) 2016-2019 The James Hutton Institute
-# Copyright (c) 2019-2020 University of Strathclyde
+# Copyright (c) 2019 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -337,12 +337,13 @@ def compile_url(filestem: str, suffix: str, ftpstem: str) -> Tuple[str, str]:
 
 # Download a remote file to the specified directory
 def download_url(
-    url: str, outfname: Path, disable_tqdm: bool = False
+    url: str, outfname: Path, timeout: int, disable_tqdm: bool = False
 ) -> None:
     """Download remote URL to a local directory.
 
     :param url:  URL of remote file for download
     :param outfname: Path, path to write output
+    :param timeout: 
     :param disable_tqdm:  Boolean, show tqdm progress bar?
 
     This function downloads the contents of the passed URL to the passed

--- a/pyani/nucmer.py
+++ b/pyani/nucmer.py
@@ -40,6 +40,9 @@
 
 import os
 
+from pathlib import Path
+from typing import List, Optional, TextIO
+
 
 class DeltaData:
 
@@ -62,19 +65,19 @@ class DeltaData:
     - subject: path to the subject sequence file
     """
 
-    def __init__(self, name, handle=None):
+    def __init__(self, name: str, handle: TextIO = None) -> None:
         """Initialise DeltaData object.
 
         :param name:
         :param handle:
         """
         self.name = name
-        self._metadata = None
-        self._comparisons = []
+        self._metadata = None  # type: Optional[DeltaMetadata]
+        self._comparisons = []  # type: List[DeltaComparison]
         if handle is not None:
             self.from_delta(handle)
 
-    def from_delta(self, handle):
+    def from_delta(self, handle: TextIO) -> None:
         """Populate the object from the passed .delta or .filter filehandle."""
         parser = DeltaIterator(handle)
         for element in parser:
@@ -133,7 +136,9 @@ class DeltaHeader:
 
     """Represents a single sequence comparison header from a MUMmer .delta file."""
 
-    def __init__(self, reference, query, reflen, querylen):
+    def __init__(
+        self, reference: Path, query: Path, reflen: int, querylen: int
+    ) -> None:
         """Initialise DeltaHeader object.
 
         :param reference:
@@ -166,7 +171,16 @@ class DeltaAlignment:
 
     """Represents a single alignment region and scores for a pairwise comparison."""
 
-    def __init__(self, refstart, refend, qrystart, qryend, errs, simerrs, stops):
+    def __init__(
+        self,
+        refstart: int,
+        refend: int,
+        qrystart: int,
+        qryend: int,
+        errs: int,
+        simerrs: int,
+        stops: int,
+    ) -> None:
         """Initialise DeltaAlignment object.
 
         :param refstart:
@@ -184,7 +198,7 @@ class DeltaAlignment:
         self.errs = int(errs)
         self.simerrs = int(simerrs)
         self.stops = int(stops)
-        self.indels = []
+        self.indels = []  # type: List[str]
 
     def __lt__(self, other):
         return (self.refstart, self.refend, self.querystart, self.queryend) < (
@@ -221,11 +235,11 @@ class DeltaMetadata:
 
     """Represents the metadata header for a MUMmer .delta file."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialise DeltaMetadata object."""
-        self.reference = None
-        self.query = None
-        self.program = None
+        self.reference = None  #  type: Optional[Path]
+        self.query = None  # type: Optional[Path]
+        self.program = None  # type: Optional[str]
 
     def __eq__(self, other):
         if not isinstance(other, DeltaMetadata):
@@ -244,7 +258,7 @@ class DeltaComparison:
 
     """Represents a comparison between two sequences in a .delta file."""
 
-    def __init__(self, header, alignments):
+    def __init__(self, header: DeltaHeader, alignments: List[DeltaAlignment]) -> None:
         """Initialise DeltaComparison object.
 
         :param header:
@@ -253,7 +267,7 @@ class DeltaComparison:
         self.header = header
         self.alignments = alignments
 
-    def add_alignment(self, aln):
+    def add_alignment(self, aln: DeltaAlignment) -> None:
         """Add passed alignment to this object.
 
         :param aln:  DeltaAlignment object
@@ -286,7 +300,7 @@ class DeltaIterator:
     http://mummer.sourceforge.net/manual/#nucmeroutput
     """
 
-    def __init__(self, handle):
+    def __init__(self, handle: TextIO) -> None:
         """Instantiate DeltaIterator object with the passed filehandle.
 
         :param handle:

--- a/pyani/pyani_classify.py
+++ b/pyani/pyani_classify.py
@@ -39,10 +39,10 @@
 # THE SOFTWARE.
 """Module providing functions to generate clusters/species hypotheses."""
 
-from typing import List, NamedTuple, Tuple
+from typing import Dict, List, NamedTuple, Tuple
 
-import networkx as nx
-import pandas as pd
+import networkx as nx  # type: ignore
+import pandas as pd  # type: ignore
 
 from pyani.pyani_tools import label_results_matrix
 
@@ -59,7 +59,7 @@ class Cliquesinfo(NamedTuple):
 
 # Build an undirected graph from an ANIResults object
 def build_graph_from_results(
-    results, label_dict, cov_min: float = 0, id_min: float = 0
+    results, label_dict: Dict[int, str], cov_min: float = 0, id_min: float = 0
 ) -> nx.Graph:
     """Return undirected graph representing the passed ANIResults object.
 

--- a/pyani/pyani_classify.py
+++ b/pyani/pyani_classify.py
@@ -39,19 +39,28 @@
 # THE SOFTWARE.
 """Module providing functions to generate clusters/species hypotheses."""
 
-from collections import namedtuple
+from typing import List, NamedTuple, Tuple
 
 import networkx as nx
 import pandas as pd
 
 from pyani.pyani_tools import label_results_matrix
 
+
 # Holds summary information about a graph's cliques
-Cliquesinfo = namedtuple("Cliquesinfo", "n_nodes n_subgraphs all_k_complete")
+class Cliquesinfo(NamedTuple):
+
+    """Summary of clique structure."""
+
+    n_nodes: int
+    n_subgraphs: int
+    all_k_complete: bool
 
 
 # Build an undirected graph from an ANIResults object
-def build_graph_from_results(results, label_dict, cov_min=0, id_min=0):
+def build_graph_from_results(
+    results, label_dict, cov_min: float = 0, id_min: float = 0
+) -> nx.Graph:
     """Return undirected graph representing the passed ANIResults object.
 
     The passed ANIResults object is converted to an undirected graph where
@@ -103,8 +112,8 @@ def build_graph_from_results(results, label_dict, cov_min=0, id_min=0):
 
 
 # Report clique info for a graph
-def analyse_cliques(graph):
-    """Return Cliquesinfo namedtuple describing clique data for a graph.
+def analyse_cliques(graph: nx.Graph) -> Cliquesinfo:
+    """Return Cliquesinfo NamedTuple describing clique data for a graph.
 
     :param graph:  NetworkX Graph object
     """
@@ -112,7 +121,7 @@ def analyse_cliques(graph):
     return Cliquesinfo(len(graph), len(subgraphs), all_components_k_complete(graph))
 
 
-def all_components_k_complete(graph):
+def all_components_k_complete(graph: nx.Graph) -> bool:
     """Return True if all components in passed graph are k-complete.
 
     :param graph:  NetworkX Graph object
@@ -120,7 +129,7 @@ def all_components_k_complete(graph):
     return all(k_complete_component_status(graph))
 
 
-def k_complete_component_status(graph):
+def k_complete_component_status(graph: nx.Graph) -> List[bool]:
     """Return list of Booleans of whether connected components of the graph are k-complete.
 
     :param graph:  NetworkX Graph object
@@ -139,7 +148,9 @@ def k_complete_component_status(graph):
     ]
 
 
-def remove_low_weight_edges(graph, threshold, attribute="identity"):
+def remove_low_weight_edges(
+    graph: nx.Graph, threshold: float, attribute: str = "identity"
+) -> Tuple[nx.Graph, List]:
     """Return graph and edgelist where edges having weight < threshold are removed.
 
     :param graph:  NetworkX Graph

--- a/pyani/pyani_config.py
+++ b/pyani/pyani_config.py
@@ -42,8 +42,11 @@
 from pathlib import Path
 from typing import Any, Dict, Tuple
 
+<<<<<<< HEAD
 import pandas as pd  # type: ignore
 
+=======
+>>>>>>> fix import issues for mypy with pyani/anim.py
 from matplotlib.colors import LinearSegmentedColormap  # type: ignore
 
 # Defaults assume that common binaries are on the $PATH

--- a/pyani/pyani_config.py
+++ b/pyani/pyani_config.py
@@ -42,7 +42,7 @@
 from pathlib import Path
 from typing import Any, Dict, Tuple
 
-import pandas as pd
+import pandas as pd  # type: ignore
 
 from matplotlib.colors import LinearSegmentedColormap  # type: ignore
 

--- a/pyani/pyani_config.py
+++ b/pyani/pyani_config.py
@@ -42,11 +42,8 @@
 from pathlib import Path
 from typing import Any, Dict, Tuple
 
-<<<<<<< HEAD
 import pandas as pd  # type: ignore
 
-=======
->>>>>>> fix import issues for mypy with pyani/anim.py
 from matplotlib.colors import LinearSegmentedColormap  # type: ignore
 
 # Defaults assume that common binaries are on the $PATH

--- a/pyani/pyani_config.py
+++ b/pyani/pyani_config.py
@@ -40,6 +40,9 @@
 """Configuration settings for the pyani package."""
 
 from pathlib import Path
+from typing import Any, Dict, Tuple
+
+import pandas as pd
 
 from matplotlib.colors import LinearSegmentedColormap  # type: ignore
 
@@ -149,7 +152,7 @@ CMAP_BURD = LinearSegmentedColormap("BuRd", cdict_BuRd)
 
 # Graphics parameters for each output file. Note that this should be
 # in sync with the output file stems above
-def params_mpl(dfm):
+def params_mpl(dfm: pd.DataFrame) -> Dict[str, Tuple[str, Any, Any]]:
     """Return dict of matplotlib parameters, dependent on dataframe.
 
     :param dfm:
@@ -176,7 +179,7 @@ def params_mpl(dfm):
     }
 
 
-def get_colormap(dataframe, matname):
+def get_colormap(dataframe: pd.DataFrame, matname: str) -> Tuple[str, Any, Any]:
     """Return colormap parameters for a dataframe.
 
     :param dataframe:

--- a/pyani/pyani_config.py
+++ b/pyani/pyani_config.py
@@ -41,7 +41,7 @@
 
 from pathlib import Path
 
-from matplotlib.colors import LinearSegmentedColormap
+from matplotlib.colors import LinearSegmentedColormap  # type: ignore
 
 # Defaults assume that common binaries are on the $PATH
 NUCMER_DEFAULT = Path("nucmer")

--- a/pyani/pyani_files.py
+++ b/pyani/pyani_files.py
@@ -180,9 +180,7 @@ def load_classes_labels(path: Path) -> Dict[str, str]:
 
 
 # Collect existing output files when in recovery mode
-def collect_existing_output(
-    dirpath: Path, program: str, args: Namespace
-) -> List[Path]:
+def collect_existing_output(dirpath: Path, program: str, args: Namespace) -> List[Path]:
     """Return a list of existing output files at dirpath.
 
     :param dirpath:  Path, path to existing output directory

--- a/pyani/pyani_files.py
+++ b/pyani/pyani_files.py
@@ -54,7 +54,7 @@ class PyaniFilesException(PyaniException):
 
 
 # Get a list of FASTA files from the input directory
-def get_fasta_files(dirname: Path = Path(".")) -> Iterable[Path]:
+def get_fasta_files(dirname: Path = Path(".")) -> List[Path]:
     """Return a list of FASTA files in the passed directory.
 
     :param dirname:  Path, path to input directory
@@ -102,7 +102,7 @@ def get_fasta_and_hash_paths(dirname: Path = Path(".")) -> List[Tuple[Path, Path
 
 
 # Get list of FASTA files in a directory
-def get_input_files(dirname: Path, *ext) -> Iterable[Path]:
+def get_input_files(dirname: Path, *ext) -> List[Path]:
     """Return files in passed directory, filtered by extension.
 
     :param dirname:  Path, path to input directory

--- a/pyani/pyani_files.py
+++ b/pyani/pyani_files.py
@@ -182,7 +182,7 @@ def load_classes_labels(path: Path) -> Dict[str, str]:
 # Collect existing output files when in recovery mode
 def collect_existing_output(
     dirpath: Path, program: str, args: Namespace
-) -> Iterable[Path]:
+) -> List[Path]:
     """Return a list of existing output files at dirpath.
 
     :param dirpath:  Path, path to existing output directory

--- a/pyani/pyani_files.py
+++ b/pyani/pyani_files.py
@@ -42,7 +42,7 @@ from argparse import Namespace
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Tuple
 
-from Bio import SeqIO
+from Bio import SeqIO  # type: ignore
 
 from pyani import PyaniException
 

--- a/pyani/pyani_graphics/__init__.py
+++ b/pyani/pyani_graphics/__init__.py
@@ -47,7 +47,6 @@
 #            generating-a-png-with-matplotlib-when-display-is-undefined
 # This needs to be done before importing pyplot
 
-from pathlib import Path
 from typing import Dict, Optional, Tuple
 
 import matplotlib  # pylint: disable=C0411

--- a/pyani/pyani_graphics/__init__.py
+++ b/pyani/pyani_graphics/__init__.py
@@ -48,7 +48,7 @@
 # This needs to be done before importing pyplot
 
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import matplotlib  # pylint: disable=C0411
 
@@ -69,8 +69,8 @@ class Params:  # pylint: disable=too-few-public-methods
     def __init__(
         self,
         params: Tuple,
-        labels: Optional[Path] = None,
-        classes: Optional[Path] = None,
+        labels: Optional[Dict] = None,
+        classes: Optional[Dict] = None,
     ):
         """Instantiate class.
 

--- a/pyani/pyani_graphics/__init__.py
+++ b/pyani/pyani_graphics/__init__.py
@@ -47,6 +47,9 @@
 #            generating-a-png-with-matplotlib-when-display-is-undefined
 # This needs to be done before importing pyplot
 
+from pathlib import Path
+from typing import Optional, Tuple
+
 import matplotlib  # pylint: disable=C0411
 
 from . import mpl  # noqa: F401  # matplotlib wrappers
@@ -63,7 +66,12 @@ class Params:  # pylint: disable=too-few-public-methods
 
     """Convenience class to hold heatmap rendering parameters."""
 
-    def __init__(self, params, labels=None, classes=None):
+    def __init__(
+        self,
+        params: Tuple,
+        labels: Optional[Path] = None,
+        classes: Optional[Path] = None,
+    ):
         """Instantiate class.
 
         :param params:

--- a/pyani/pyani_graphics/mpl/__init__.py
+++ b/pyani/pyani_graphics/mpl/__init__.py
@@ -148,7 +148,7 @@ def distribution(dfr, outfilename, matname, title=None):
     axes[0].hist(data, bins=50)
     # Plot density
     density = gaussian_kde(data)
-    density._compute_covariance()
+    density._compute_covariance()  # pylint: disable=protected-access
     axes[1].plot(xvals, density(xvals))
 
     # Modify axes after data is plotted

--- a/pyani/pyani_graphics/sns/__init__.py
+++ b/pyani/pyani_graphics/sns/__init__.py
@@ -43,7 +43,7 @@ import pandas as pd
 import seaborn as sns
 
 matplotlib.use("Agg")
-import matplotlib.pyplot as plt  # noqa: E402 # pylint: disable=wrong-import-position,wrong-import-order
+import matplotlib.pyplot as plt  # noqa: E402,E501 # pylint: disable=wrong-import-position,wrong-import-order,ungrouped-imports
 
 
 # Add classes colorbar to Seaborn plot

--- a/pyani/pyani_orm.py
+++ b/pyani/pyani_orm.py
@@ -45,14 +45,14 @@ This SQLAlchemy-based ORM replaces the previous SQL-based module
 from pathlib import Path
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
-import numpy as np
-import pandas as pd
+import numpy as np  # type: ignore
+import pandas as pd  # type: ignore
 
-from sqlalchemy import and_
+from sqlalchemy import and_   # type: ignore
 from sqlalchemy import UniqueConstraint, create_engine, Table
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Float, Boolean
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import relationship, sessionmaker
+from sqlalchemy.ext.declarative import declarative_base  # type: ignore
+from sqlalchemy.orm import relationship, sessionmaker  # type: ignore
 
 from pyani import PyaniException
 from pyani.pyani_files import (

--- a/pyani/pyani_orm.py
+++ b/pyani/pyani_orm.py
@@ -42,7 +42,8 @@
 This SQLAlchemy-based ORM replaces the previous SQL-based module
 """
 
-from collections import namedtuple
+from pathlib import Path
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -70,7 +71,8 @@ class PyaniORMException(PyaniException):
 
 # Using the declarative system
 # We follow Flask-like naming conventions, so override some of the pyline errors
-Base = declarative_base()  # pylint: disable=C0103
+# Mypy doesn't like dynamic base classes, see https://github.com/python/mypy/issues/2477
+Base = declarative_base()  # type: Any
 Session = sessionmaker()  # pylint: disable=C0103
 
 # Linker table between genomes and runs tables
@@ -90,8 +92,13 @@ runcomparison = Table(  # pylint: disable=C0103
 )
 
 
-# Convenience struct for labels and classes files
-LabelTuple = namedtuple("LabelTuple", "label class_label")
+# Convenience struct for labels and classes
+class LabelTuple(NamedTuple):
+
+    """Label and Class for each file."""
+
+    label: str
+    class_label: str
 
 
 class Label(Base):
@@ -112,7 +119,7 @@ class Label(Base):
     genome = relationship("Genome", back_populates="labels")
     run = relationship("Run", back_populates="labels")
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return string representation of Label table row."""
         return str(
             "Genome ID: {}, Run ID: {}, Label ID: {}, Label: {}, Class: {}".format(
@@ -120,7 +127,7 @@ class Label(Base):
             )
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return string representation of Label table object."""
         return "<Label(key=({}, {}, {}))>".format(
             self.label_id, self.run_id, self.genome_id
@@ -153,7 +160,7 @@ class BlastDB(Base):
     genome = relationship("Genome", back_populates="blastdbs")
     run = relationship("Run", back_populates="blastdbs")
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return string representation of BlastDB table row."""
         return str(
             "BlastDB: {}, Run ID: {}, Label ID: {}, Label: {}, Class: {}".format(
@@ -161,7 +168,7 @@ class BlastDB(Base):
             )
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return string representation of BlastDB table object."""
         return "<BlastDB(key=({}, {}, {}))>".format(
             self.label_id, self.run_id, self.genome_id
@@ -209,11 +216,11 @@ class Genome(Base):
         primaryjoin="Genome.genome_id == Comparison.subject_id",
     )
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return string representation of Genome table row."""
         return str("Genome {}: {}".format(self.genome_id, self.description))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return string representation of Genome table object."""
         return "<Genome(id='{}',desc='{}')>".format(self.genome_id, self.description)
 
@@ -245,11 +252,11 @@ class Run(Base):
     labels = relationship("Label", back_populates="run", lazy="dynamic")
     blastdbs = relationship("BlastDB", back_populates="run", lazy="dynamic")
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return string representation of Run table row."""
         return str("Run {}: {} ({})".format(self.run_id, self.name, self.date))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return string representation of Run table object."""
         return "<Run(run_id={})>".format(self.run_id)
 
@@ -288,7 +295,7 @@ class Comparison(Base):
         "Run", secondary=runcomparison, back_populates="comparisons", lazy="dynamic"
     )
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return string representation of Comparison table row."""
         return str(
             "Query: {}, Subject: {}, %%ID={}, ({} {})".format(
@@ -300,12 +307,12 @@ class Comparison(Base):
             )
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return string representation of Comparison table object."""
         return "<Comparison(comparison_id={})>".format(self.comparison_id)
 
 
-def create_db(dbpath):
+def create_db(dbpath: Path) -> None:
     """Create an empty pyani SQLite3 database at the passed path.
 
     :param dbpath:  path to pyani database
@@ -314,7 +321,7 @@ def create_db(dbpath):
     Base.metadata.create_all(engine)
 
 
-def get_session(dbpath):
+def get_session(dbpath: Path) -> Any:
     """Connect to an existing pyani SQLite3 database and return a session.
 
     :param dbpath: path to pyani database
@@ -324,7 +331,7 @@ def get_session(dbpath):
     return Session()
 
 
-def get_comparison_dict(session):
+def get_comparison_dict(session: Any) -> Dict[Tuple, Any]:
     """Return a dictionary of comparisons in the session database.
 
     :param session:      live SQLAlchemy session of pyani database
@@ -338,7 +345,7 @@ def get_comparison_dict(session):
     }
 
 
-def get_matrix_labels_for_run(session, run_id):
+def get_matrix_labels_for_run(session: Any, run_id: int) -> Dict:
     """Return dictionary of genome labels, keyed by row/column ID.
 
     :param session:  live SQLAlchemy session
@@ -362,7 +369,7 @@ def get_matrix_labels_for_run(session, run_id):
     return {str(_.genome_id): _.label for _ in results}
 
 
-def get_matrix_classes_for_run(session, run_id):
+def get_matrix_classes_for_run(session: Any, run_id: int) -> Dict[str, List]:
     """Return dictionary of genome classes, keyed by row/column ID.
 
     :param session:  live SQLAlchemy session
@@ -387,8 +394,8 @@ def get_matrix_classes_for_run(session, run_id):
 
 
 def filter_existing_comparisons(
-    session, run, comparisons, program, version, fragsize=None, maxmatch=None
-):
+    session, run, comparisons, program, version, fragsize: Optional[int] = None, maxmatch: Optional[bool] = None
+) -> List:
     """Filter list of (Genome, Genome) comparisons for those not in the session db.
 
     :param session:       live SQLAlchemy session of pyani database
@@ -453,7 +460,7 @@ def add_run(session, method, cmdline, date, status, name):
     return run
 
 
-def add_run_genomes(session, run, indir, classpath=None, labelpath=None):
+def add_run_genomes(session, run, indir: Path, classpath: Path, labelpath: Path) -> List:
     """Add genomes for a run to the database.
 
     :param session:       live SQLAlchemy session of pyani database
@@ -475,7 +482,9 @@ def add_run_genomes(session, run, indir, classpath=None, labelpath=None):
     """
     # Get list of genome files and paths to class and labels files
     infiles = get_fasta_and_hash_paths(indir)  # paired FASTA/hash files
-    class_data, label_data, all_keys = None, None, []
+    class_data = {}  # type: Dict[str,str]
+    label_data = {}  # type: Dict[str,str]
+    all_keys = []  # type: List[str]
     if classpath:
         class_data = load_classes_labels(classpath)
         all_keys += list(class_data.keys())
@@ -485,9 +494,9 @@ def add_run_genomes(session, run, indir, classpath=None, labelpath=None):
 
     # Make dictionary of labels and/or classes
     new_keys = set(all_keys)
-    label_dict = {}
+    label_dict = {}  # type: Dict
     for key in new_keys:
-        label_dict[key] = LabelTuple(label_data[key] or None, class_data[key] or None)
+        label_dict[key] = LabelTuple(label_data[key] or "", class_data[key] or "")
 
     # Get hash and sequence description for each FASTA/hash pair, and add
     # to current session database
@@ -548,7 +557,7 @@ def add_run_genomes(session, run, indir, classpath=None, labelpath=None):
     return genome_ids
 
 
-def update_comparison_matrices(session, run):
+def update_comparison_matrices(session, run) -> None:
     """Update the Run table with summary matrices for the analysis.
 
     :param session:       active pyanidb session via ORM

--- a/pyani/pyani_report.py
+++ b/pyani/pyani_report.py
@@ -40,8 +40,15 @@
 
 import sys
 
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
 
-def colour_rows(series, even_colour="#DDECF5", odd_colour="#6CB6E4"):
+import pandas as pd
+
+
+def colour_rows(
+    series: pd.Series, even_colour: str = "#DDECF5", odd_colour: str = "#6CB6E4"
+) -> List[str]:
     """Return alternating colours for rows in a dataframe.
 
     :param series:  pd.Series
@@ -57,12 +64,12 @@ def colour_rows(series, even_colour="#DDECF5", odd_colour="#6CB6E4"):
     ]
 
 
-def table_padding():
+def table_padding() -> Dict[str, Any]:
     """Return HTML for table cell padding."""
     return dict(selector="td", props=[("padding", "15px")])
 
 
-def hover_highlight(hover_colour="#FFFF99"):
+def hover_highlight(hover_colour: str = "#FFFF99") -> Dict[str, Any]:
     """Return HTML style to colour dataframe row when hovering.
 
     :param hover_colour:  str, hex colour for hover highlight
@@ -70,7 +77,7 @@ def hover_highlight(hover_colour="#FFFF99"):
     return dict(selector="tr:hover", props=[("background-color", "%s" % hover_colour)])
 
 
-def header_font():
+def header_font() -> Dict[str, Any]:
     """Return header HTML font style."""
     return dict(
         selector="th",
@@ -82,7 +89,9 @@ def header_font():
     )
 
 
-def colour_identity(series, threshold=0.95, colour="#FF2222"):
+def colour_identity(
+    series: pd.Series, threshold: float = 0.95, colour: str = "#FF2222"
+) -> List[str]:
     """Highlight percentage identities over a threshold.
 
     :param series:
@@ -95,7 +104,9 @@ def colour_identity(series, threshold=0.95, colour="#FF2222"):
     return ["" for v in series]
 
 
-def colour_coverage(series, threshold=0.95, colour="#FF2222"):
+def colour_coverage(
+    series: pd.Series, threshold: float = 0.95, colour: str = "#FF2222"
+) -> List[str]:
     """Highlight percent coverage over a threshold.
 
     :param series:
@@ -108,7 +119,7 @@ def colour_coverage(series, threshold=0.95, colour="#FF2222"):
     return ["" for v in series]
 
 
-def colour_numeric(val, threshold=0.95, colour="#FF2222"):
+def colour_numeric(val: float, threshold: float = 0.95, colour: str = "#FF2222") -> str:
     """Highlight numeric values over a threshold.
 
     :param val:
@@ -121,7 +132,9 @@ def colour_numeric(val, threshold=0.95, colour="#FF2222"):
 
 
 # Write a dataframe in pyani-styled HTML
-def write_styled_html(path, dfm, index=None, colour_num=False):
+def write_styled_html(
+    path: Path, dfm: pd.DataFrame, index: Optional[str] = None, colour_num: bool = False
+) -> None:
     """Add CSS styling to a dataframe and write as HTML.
 
     :param path:       path to write output file
@@ -157,7 +170,9 @@ def write_styled_html(path, dfm, index=None, colour_num=False):
 
 
 # Write a dataframe to STDOUT
-def write_to_stdout(stem, dfm, show_index=False, line_width=None):
+def write_to_stdout(
+    stem: str, dfm: pd.DataFrame, show_index: bool = False, line_width: float = None
+) -> None:
     """Write dataframe in tab-separated form to STDOUT.
 
     :param stem:  str
@@ -171,8 +186,13 @@ def write_to_stdout(stem, dfm, show_index=False, line_width=None):
 
 # Write a table returned from the pyani database in the requested format
 def write_dbtable(
-    dfm, path=None, formats=("tab",), index=False, show_index=False, colour_num=False
-):
+    dfm: pd.DataFrame,
+    path: Path,
+    formats: Tuple[str] = ("tab",),
+    index: bool = False,
+    show_index: bool = False,
+    colour_num: bool = False,
+) -> None:
     """Write database result table to output file in named format.
 
     :param dfm:  pd.Dataframe

--- a/pyani/pyani_report.py
+++ b/pyani/pyani_report.py
@@ -43,7 +43,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-import pandas as pd
+import pandas as pd  # type: ignore
 
 
 def colour_rows(

--- a/pyani/pyani_report.py
+++ b/pyani/pyani_report.py
@@ -41,7 +41,7 @@
 import sys
 
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sequence
 
 import pandas as pd  # type: ignore
 
@@ -188,7 +188,7 @@ def write_to_stdout(
 def write_dbtable(
     dfm: pd.DataFrame,
     path: Path,
-    formats: Tuple[str] = ("tab",),
+    formats: Sequence[str] = ("tab",),
     index: bool = False,
     show_index: bool = False,
     colour_num: bool = False,

--- a/pyani/pyani_tools.py
+++ b/pyani/pyani_tools.py
@@ -44,6 +44,7 @@ import shutil
 
 from collections import namedtuple
 from pathlib import Path
+from typing import Any, Iterator, List, Optional, Tuple
 
 import pandas as pd  # type: ignore
 
@@ -66,7 +67,7 @@ class ANIResults:
 
     """Holds ANI dataframe results."""
 
-    def __init__(self, labels, mode):
+    def __init__(self, labels: List[str], mode: str) -> None:
         """Initialise with four empty, labelled dataframes.
 
         :param labels:
@@ -85,7 +86,9 @@ class ANIResults:
         self.zero_error = False
         self.mode = mode
 
-    def add_tot_length(self, qname, sname, value, sym=True):
+    def add_tot_length(
+        self, qname: str, sname: str, value: float, sym: bool = True
+    ) -> None:
         """Add a total length value to self.alignment_lengths.
 
         :param qname:
@@ -97,7 +100,9 @@ class ANIResults:
         if sym:
             self.alignment_lengths.loc[sname, qname] = value
 
-    def add_sim_errors(self, qname, sname, value, sym=True):
+    def add_sim_errors(
+        self, qname: str, sname: str, value: float, sym: bool = True
+    ) -> None:
         """Add a similarity error value to self.similarity_errors.
 
         :param qname:
@@ -109,7 +114,7 @@ class ANIResults:
         if sym:
             self.similarity_errors.loc[sname, qname] = value
 
-    def add_pid(self, qname, sname, value, sym=True):
+    def add_pid(self, qname: str, sname: str, value: str, sym: bool = True) -> None:
         """Add a percentage identity value to self.percentage_identity.
 
         :param qname:
@@ -121,7 +126,9 @@ class ANIResults:
         if sym:
             self.percentage_identity.loc[sname, qname] = value
 
-    def add_coverage(self, qname, sname, qcover, scover=None):
+    def add_coverage(
+        self, qname: str, sname: str, qcover: float, scover: Optional[float] = None
+    ) -> None:
         """Add percentage coverage values to self.alignment_coverage.
 
         :param qname:
@@ -134,12 +141,12 @@ class ANIResults:
             self.alignment_coverage.loc[sname, qname] = scover
 
     @property
-    def hadamard(self):
+    def hadamard(self) -> float:
         """Return Hadamard matrix (identity * coverage)."""
         return self.percentage_identity * self.alignment_coverage
 
     @property
-    def data(self):
+    def data(self) -> Iterator[Tuple[Any, str]]:
         """Return list of (dataframe, filestem) tuples."""
         stemdict = {
             "ANIm": pyani_config.ANIM_FILESTEMS,
@@ -190,7 +197,7 @@ class BLASTcmds:
 
     """Class for construction of BLASTN and database formatting commands."""
 
-    def __init__(self, funcs, exes, prefix: str, outdir: Path):
+    def __init__(self, funcs, exes, prefix: str, outdir: Path) -> None:
         """Instantiate class.
 
         :param funcs:

--- a/pyani/pyani_tools.py
+++ b/pyani/pyani_tools.py
@@ -133,7 +133,7 @@ class ANIResults:
         if sym:
             self.similarity_errors.loc[sname, qname] = value
 
-    def add_pid(self, qname: str, sname: str, value: str, sym: bool = True) -> None:
+    def add_pid(self, qname: str, sname: str, value: float, sym: bool = True) -> None:
         """Add a percentage identity value to self.percentage_identity.
 
         :param qname:

--- a/pyani/pyani_tools.py
+++ b/pyani/pyani_tools.py
@@ -44,9 +44,9 @@ import shutil
 
 from collections import namedtuple
 
-import pandas as pd
+import pandas as pd  # type: ignore
 
-from Bio import SeqIO
+from Bio import SeqIO  # type: ignore
 
 from . import pyani_config, download
 

--- a/pyani/pyani_tools.py
+++ b/pyani/pyani_tools.py
@@ -43,6 +43,7 @@
 import shutil
 
 from collections import namedtuple
+from pathlib import Path
 
 import pandas as pd  # type: ignore
 
@@ -189,7 +190,7 @@ class BLASTcmds:
 
     """Class for construction of BLASTN and database formatting commands."""
 
-    def __init__(self, funcs, exes, prefix, outdir):
+    def __init__(self, funcs, exes, prefix: str, outdir: Path):
         """Instantiate class.
 
         :param funcs:
@@ -202,25 +203,25 @@ class BLASTcmds:
         self.prefix = prefix
         self.outdir = outdir
 
-    def build_db_cmd(self, fname):
+    def build_db_cmd(self, fname: Path) -> str:
         """Return database format/build command.
 
         :param fname:
         """
         return self.funcs.db_func(fname, self.outdir, self.exes.format_exe)[0]
 
-    def get_db_name(self, fname):
+    def get_db_name(self, fname: Path) -> str:
         """Return database filename.
 
         :param fname:
         """
         return self.funcs.db_func(fname, self.outdir, self.exes.format_exe)[1]
 
-    def build_blast_cmd(self, fname, dbname):
+    def build_blast_cmd(self, fname: Path, dbname: Path):
         """Return BLASTN command.
 
-        :param fname:
-        :param dbname:
+        :param fname:  Path to query file
+        :param dbname:  Path to database
         """
         return self.funcs.blastn_func(fname, dbname, self.outdir, self.exes.blast_exe)
 

--- a/pyani/run_multiprocessing.py
+++ b/pyani/run_multiprocessing.py
@@ -49,7 +49,7 @@ import sys
 from logging import Logger
 from typing import List, Optional
 
-from pyani_jobs import Job
+from .pyani_jobs import Job
 
 
 # Run a job dependency graph with multiprocessing

--- a/pyani/run_multiprocessing.py
+++ b/pyani/run_multiprocessing.py
@@ -46,11 +46,16 @@ import multiprocessing
 import subprocess
 import sys
 
-CUMRETVAL = 0
+from logging import Logger
+from typing import List, Optional
+
+from pyani_jobs import Job
 
 
 # Run a job dependency graph with multiprocessing
-def run_dependency_graph(jobgraph, workers=None, logger=None):
+def run_dependency_graph(
+    jobgraph, workers: Optional[int] = None, logger: Optional[Logger] = None
+) -> int:
     """Create and run pools of jobs based on the passed jobgraph.
 
     :param jobgraph:  list of jobs, which may have dependencies.
@@ -61,7 +66,7 @@ def run_dependency_graph(jobgraph, workers=None, logger=None):
     and create/populate a series of Sets of commands, to be run in
     reverse order with multiprocessing_run as asynchronous pools.
     """
-    cmdsets = []
+    cmdsets = []  # type: List
     for job in jobgraph:
         cmdsets = populate_cmdsets(job, cmdsets, depth=1)
 
@@ -79,7 +84,7 @@ def run_dependency_graph(jobgraph, workers=None, logger=None):
     return cumretval
 
 
-def populate_cmdsets(job, cmdsets, depth):
+def populate_cmdsets(job: Job, cmdsets: List, depth: int) -> List:
     """Create list of jobsets at different depths of dependency tree.
 
     :param job:
@@ -105,7 +110,7 @@ def populate_cmdsets(job, cmdsets, depth):
 
 
 # Run a set of command lines using multiprocessing
-def multiprocessing_run(cmdlines, workers=None):
+def multiprocessing_run(cmdlines: List, workers: Optional[int] = None) -> int:
     """Distributes passed command-line jobs using multiprocessing.
 
     :param cmdlines:  iterable, command line strings

--- a/pyani/run_sge.py
+++ b/pyani/run_sge.py
@@ -44,16 +44,17 @@ jobs.
 
 import itertools
 import os
-import subprocess  # nosec
 
 from collections import defaultdict
+from logging import Logger
 from pathlib import Path
+from typing import Dict, Generator, Iterable, List, Optional, Set
 
 from . import pyani_config
-from .pyani_jobs import JobGroup
+from .pyani_jobs import Job, JobGroup
 
 
-def split_seq(iterable, size):
+def split_seq(iterable: Iterable, size: int) -> Generator:
     """Split a passed iterable into chunks of a given size.
 
     :param iterable:  iterable
@@ -67,29 +68,31 @@ def split_seq(iterable, size):
 
 
 # Build a list of SGE jobs from a graph
-def build_joblist(jobgraph):
+def build_joblist(jobgraph) -> List:
     """Return a list of jobs, from a passed jobgraph.
 
     :param jobgraph:
     """
-    jobset = set()
+    jobset = set()  # type: Set
     for job in jobgraph:
         jobset = populate_jobset(job, jobset, depth=1)
     return list(jobset)
 
 
 # Convert joblist into jobgroups
-def compile_jobgroups_from_joblist(joblist, jgprefix, sgegroupsize):
+def compile_jobgroups_from_joblist(
+    joblist: List, jgprefix: str, sgegroupsize: int
+) -> List:
     """Return list of jobgroups, rather than list of jobs.
 
     :param joblist:
     :param jgprefix:  str, prefix for SGE jobgroup
     :param sgegroupsize:  int, number of jobs in each SGE jobgroup
     """
-    jobcmds = defaultdict(list)
+    jobcmds = defaultdict(list)  # type: Dict[str, List[str]]
     for job in joblist:
         jobcmds[job.command.split(" ", 1)[0]].append(job.command)
-    jobgroups = []
+    jobgroups = []  # type: List
     for cmds in list(jobcmds.items()):
         # Break arglist up into batches of sgegroupsize (default: 10,000)
         sublists = split_seq(cmds[1], sgegroupsize)
@@ -99,7 +102,7 @@ def compile_jobgroups_from_joblist(joblist, jgprefix, sgegroupsize):
             sge_jobcmdlist = [f'"{jc}"' for jc in sublist]
             jobgroups.append(
                 JobGroup(
-                    f"{jgprefix}_{count}" "$cmds", arguments={"cmds": sge_jobcmdlist}
+                    f"{jgprefix}_{count}", "$cmds", arguments={"cmds": sge_jobcmdlist}
                 )
             )
     return jobgroups
@@ -107,8 +110,12 @@ def compile_jobgroups_from_joblist(joblist, jgprefix, sgegroupsize):
 
 # Run a job dependency graph, with SGE
 def run_dependency_graph(
-    jobgraph, logger=None, jgprefix="ANIm_SGE_JG", sgegroupsize=10000, sgeargs=None
-):
+    jobgraph,
+    logger: Optional[Logger] = None,
+    jgprefix: str = "ANIm_SGE_JG",
+    sgegroupsize: int = 10000,
+    sgeargs: Optional[str] = None,
+) -> None:
     """Create and runs SGE scripts for jobs based on passed jobgraph.
 
     :param jobgraph: list of jobs, which may have dependencies.
@@ -139,7 +146,7 @@ def run_dependency_graph(
                 for dep in job.dependencies:
                     logger.info("\t[^ depends on: %s (%s)]", dep.name, dep.command)
                     jobs_deps.append(dep)
-    logger.info("There are %d job dependencies" % dep_count)
+        logger.info("There are %d job dependencies" % dep_count)
     # Clear dependencies in main group
     for job in jobs_main:
         job.dependencies = []
@@ -149,7 +156,8 @@ def run_dependency_graph(
     # the queue.
     # We split the main and dependent jobs into separate JobGroups.
     # These JobGroups are paired, in order
-    logger.info("Compiling main and dependent jobs into separate JobGroups")
+    if logger:
+        logger.info("Compiling main and dependent jobs into separate JobGroups")
     maingroups = compile_jobgroups_from_joblist(
         jobs_main, jgprefix + "_main", sgegroupsize
     )
@@ -163,17 +171,19 @@ def run_dependency_graph(
     jobgroups = maingroups + depgroups
 
     # Send jobs to scheduler
-    logger.info("Running jobs with scheduler...")
-    logger.info("Jobs passed to scheduler in order:")
-    for job in jobgroups:
-        logger.info("\t%s" % job.name)
-    build_and_submit_jobs(Path.cwd, jobgroups, sgeargs)
-    logger.info("Waiting for SGE-submitted jobs to finish (polling)")
+    if logger:
+        logger.info("Running jobs with scheduler...")
+        logger.info("Jobs passed to scheduler in order:")
+        for job in jobgroups:
+            logger.info("\t%s" % job.name)
+    build_and_submit_jobs(Path.cwd(), jobgroups, sgeargs)
+    if logger:
+        logger.info("Waiting for SGE-submitted jobs to finish (polling)")
     for job in jobgroups:
         job.wait()
 
 
-def populate_jobset(job, jobset, depth):
+def populate_jobset(job: Job, jobset: Set, depth: int) -> Set:
     """Create set of jobs reflecting dependency tree.
 
     :param job:
@@ -191,7 +201,7 @@ def populate_jobset(job, jobset, depth):
     return jobset
 
 
-def build_directories(root_dir):
+def build_directories(root_dir: Path) -> None:
     """Construct the subdirectories output, stderr, stdout, and jobs.
 
     :param root_dir:  path of root directory in which to place output
@@ -218,7 +228,7 @@ def build_directories(root_dir):
         dirname.mkdir(exist_ok=True)
 
 
-def build_job_scripts(root_dir, jobs):
+def build_job_scripts(root_dir: Path, jobs: List) -> None:
     """Construct script for each passed Job in the jobs iterable.
 
     :param root_dir:  Path to output directory
@@ -233,7 +243,7 @@ def build_job_scripts(root_dir, jobs):
         job.scriptpath = scriptpath
 
 
-def extract_submittable_jobs(waiting):
+def extract_submittable_jobs(waiting: List) -> List:
     """Obtain list of jobs that are able to be submitted from pending list.
 
     :param waiting:  list of Job objects
@@ -249,7 +259,9 @@ def extract_submittable_jobs(waiting):
     return list(submittable)
 
 
-def submit_safe_jobs(root_dir, jobs, sgeargs=None):
+def submit_safe_jobs(
+    root_dir: Path, jobs: Iterable, sgeargs: Optional[str] = None
+) -> None:
     """Submit passed list of jobs to SGE server with dir as root for output.
 
     :param root_dir:  path to output directory
@@ -294,7 +306,7 @@ def submit_safe_jobs(root_dir, jobs, sgeargs=None):
         job.submitted = True  # Set the job's submitted flag to True
 
 
-def submit_jobs(root_dir, jobs, sgeargs=None):
+def submit_jobs(root_dir: Path, jobs: Iterable, sgeargs: Optional[str] = None) -> None:
     """Submit passed jobs to SGE server with passed directory as root.
 
     :param root_dir:  path to output directory
@@ -313,7 +325,9 @@ def submit_jobs(root_dir, jobs, sgeargs=None):
             waiting.remove(job)
 
 
-def build_and_submit_jobs(root_dir, jobs, sgeargs=None):
+def build_and_submit_jobs(
+    root_dir: Path, jobs: Iterable, sgeargs: Optional[str] = None
+) -> None:
     """Submit passed iterable of Job objects to SGE.
 
     :param root_dir:  root directory for SGE and job output

--- a/pyani/scripts/average_nucleotide_identity.py
+++ b/pyani/scripts/average_nucleotide_identity.py
@@ -780,11 +780,11 @@ def draw(args, logger, filestems, gformat):
             pyani_tools.get_labels(args.classes),
         )
         if args.gmethod == "mpl":
-            pyani_graphics.heatmap_mpl(
+            pyani_graphics.mpl.heatmap()(
                 dfm, outfilename=outfilename, title=filestem, params=params
             )
         elif args.gmethod == "seaborn":
-            pyani_graphics.heatmap_seaborn(
+            pyani_graphics.sns.heatmap()(
                 dfm, outfilename=outfilename, title=filestem, params=params
             )
 

--- a/pyani/scripts/average_nucleotide_identity.py
+++ b/pyani/scripts/average_nucleotide_identity.py
@@ -780,11 +780,11 @@ def draw(args, logger, filestems, gformat):
             pyani_tools.get_labels(args.classes),
         )
         if args.gmethod == "mpl":
-            pyani_graphics.mpl.heatmap()(
+            pyani_graphics.mpl.heatmap(
                 dfm, outfilename=outfilename, title=filestem, params=params
             )
         elif args.gmethod == "seaborn":
-            pyani_graphics.sns.heatmap()(
+            pyani_graphics.sns.heatmap(
                 dfm, outfilename=outfilename, title=filestem, params=params
             )
 

--- a/pyani/scripts/average_nucleotide_identity.py
+++ b/pyani/scripts/average_nucleotide_identity.py
@@ -553,10 +553,9 @@ def calculate_anim(args, logger, infiles, org_lengths):
 
 
 # Calculate TETRA for input
-def calculate_tetra(args, logger, infiles):
+def calculate_tetra(logger, infiles):
     """Calculate TETRA for files in input directory.
 
-    :param args: Namespace, command-line arguments
     :param logger:  logging object
     :param infiles:  list, paths to each input file
 

--- a/pyani/scripts/average_nucleotide_identity.py
+++ b/pyani/scripts/average_nucleotide_identity.py
@@ -131,7 +131,10 @@ import tarfile
 import time
 import traceback
 
-from argparse import ArgumentParser
+from argparse import ArgumentParser, Namespace
+from logging import Logger
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -154,7 +157,7 @@ from pyani.scripts import logger as pyani_logger
 
 
 # Process command-line arguments
-def parse_cmdline(argv=None):
+def parse_cmdline(argv: Optional[List] = None) -> Namespace:
     """Parse command-line arguments for script.
 
     :param argv:  list of arguments from command-line
@@ -413,14 +416,14 @@ def parse_cmdline(argv=None):
 
 
 # Report last exception as string
-def last_exception():
+def last_exception() -> str:
     """Return last exception as a string, or use in logging."""
     exc_type, exc_value, exc_traceback = sys.exc_info()
     return "".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
 
 
 # Create output directory if it doesn't exist
-def make_outdirs(args, logger):
+def make_outdirs(args: Namespace, logger: Logger):
     """Make the output directory, if required.
 
     :param args:  Namespace of command-line options
@@ -451,19 +454,19 @@ def make_outdirs(args, logger):
 
 
 # Compress output directory and delete it
-def compress_delete_outdir(outdir, logger):
+def compress_delete_outdir(outdir: Path, logger: Logger) -> None:
     """Compress the contents of the passed directory to .tar.gz and delete."""
     # Compress output in .tar.gz file and remove raw output
-    tarfn = outdir + ".tar.gz"
+    tarfn = outdir.with_suffix(".tar.gz")
     logger.info("\tCompressing output from %s to %s", outdir, tarfn)
-    with tarfile.open(tarfn, "w:gz") as ofh:
-        ofh.add(outdir)
+    with tarfile.open(str(tarfn), "w:gz") as ofh:
+        ofh.add(str(outdir))
     logger.info("\tRemoving output directory %s", outdir)
     shutil.rmtree(outdir)
 
 
 # Calculate ANIm for input
-def calculate_anim(args, logger, infiles, org_lengths):
+def calculate_anim(args: Namespace, logger: Logger, infiles: List[Path], org_lengths: Dict) -> pyani_tools.ANIResults:
     """Return ANIm result dataframes for files in input directory.
 
     :param args:  Namespace, command-line arguments
@@ -553,7 +556,7 @@ def calculate_anim(args, logger, infiles, org_lengths):
 
 
 # Calculate TETRA for input
-def calculate_tetra(logger, infiles):
+def calculate_tetra(logger: Logger, infiles: List[Path]) -> pd.DataFrame:
     """Calculate TETRA for files in input directory.
 
     :param logger:  logging object
@@ -584,7 +587,7 @@ def calculate_tetra(logger, infiles):
     return tetra_correlations
 
 
-def make_sequence_fragments(args, logger, infiles, blastdir):
+def make_sequence_fragments(args: Namespace, logger: Logger, infiles: List[Path], blastdir: Path) -> Tuple[List, Dict]:
     """Return tuple of fragment files, and fragment sizes.
 
     :param args:  Namespace of command-line arguments
@@ -606,7 +609,7 @@ def make_sequence_fragments(args, logger, infiles, blastdir):
     return fragfiles, fraglengths
 
 
-def run_blast(args, logger, infiles, blastdir):
+def run_blast(args: Namespace, logger: Logger, infiles: List[Path], blastdir: Path) -> Tuple:
     """Run BLAST commands for ANIb methods.
 
     :param args:  Namespace of command-line options
@@ -653,13 +656,13 @@ def run_blast(args, logger, infiles, blastdir):
             with open(fragpath, "rU") as ifh:
                 fraglengths = json.load(ifh)
         else:
-            fraglengths = None
+            fraglengths = dict()
 
     return cumval, fraglengths
 
 
 # Calculate ANIb for input
-def unified_anib(args, logger, infiles, org_lengths):
+def unified_anib(args: Namespace, logger: Logger, infiles: List[Path], org_lengths: Dict[str, int]) -> pyani_tools.ANIResults:
     """Calculate ANIb for files in input directory.
 
     :param args:  Namespace of command-line options
@@ -729,7 +732,7 @@ def unified_anib(args, logger, infiles, org_lengths):
 
 
 # Write ANIb/ANIm/TETRA output
-def write(args, logger, results):
+def write(args: Namespace, logger: Logger, results: pd.DataFrame) -> None:
     """Write ANIb/ANIm/TETRA results to output directory.
 
     :param args:  Namespace, command-line arguments
@@ -758,7 +761,7 @@ def write(args, logger, results):
 
 
 # Draw ANIb/ANIm/TETRA output
-def draw(args, logger, filestems, gformat):
+def draw(args: Namespace, logger: Logger, filestems: List[str], gformat: str) -> None:
     """Draw ANIb/ANIm/TETRA results.
 
     :param args:  Namespace, command-line arguments
@@ -789,7 +792,7 @@ def draw(args, logger, filestems, gformat):
 
 
 # Subsample the input files
-def subsample_input(args, logger, infiles):
+def subsample_input(args: Namespace, logger: Logger, infiles: List[Path]) -> List[Path]:
     """Return a random subsample of the passed input files.
 
     :param args:  Namespace, command-line arguments
@@ -823,7 +826,7 @@ def subsample_input(args, logger, infiles):
     return random.sample(infiles, k)
 
 
-def process_arguments(args):
+def process_arguments(args: Optional[Namespace]) -> Namespace:
     """Process command-line arguments.
 
     :param args:  Namespace of command-line arguments
@@ -842,7 +845,7 @@ def process_arguments(args):
     return args
 
 
-def build_logger(args, logger):
+def build_logger(args: Namespace, logger: Optional[Logger]) -> Logger:
     """Return a logging object for the script.
 
     :param args:  Namespace of command-line arguments
@@ -879,7 +882,7 @@ def build_logger(args, logger):
     return logger
 
 
-def test_class_label_paths(args, logger):
+def test_class_label_paths(args: Namespace, logger: Logger) -> None:
     """Raise error and exit if label and class files exist.
 
     :param args:  Namespace of command-line arguments
@@ -895,7 +898,7 @@ def test_class_label_paths(args, logger):
         raise SystemExit(1)
 
 
-def get_method(args, logger):
+def get_method(args: Namespace, logger: Logger) -> Tuple:
     """Return function and config for the chosen method.
 
     :param args:  Namespace of command-line arguments
@@ -921,7 +924,7 @@ def get_method(args, logger):
     return methods[args.method]
 
 
-def test_scheduler(args, logger):
+def test_scheduler(args: Namespace, logger: Logger) -> None:
     """Test if the specified scheduler can be used.
 
     :param args:  Namespace of command-line arguments
@@ -940,16 +943,16 @@ def test_scheduler(args, logger):
 
 
 # Main function
-def run_main(args=None, logger=None):
+def run_main(argsin: Optional[Namespace] = None, logger: Optional[Logger] = None) -> int:
     """Run main process for average_nucleotide_identity.py script.
 
-    :param args:  Namespace, command-line arguments
+    :param argsin:  Namespace, command-line arguments
     :param logger:  logging object
     """
     time0 = time.time()
 
     # Process command-line and build logger
-    args = process_arguments(args)
+    args = process_arguments(argsin)
     logger = build_logger(args, logger)
 
     # Ensure argument validity and get method function/config
@@ -966,12 +969,12 @@ def run_main(args=None, logger=None):
         # Run ANI comparisons
         logger.info("Identifying FASTA files in %s", args.indirname)
         infiles = pyani_files.get_fasta_files(args.indirname)
-        logger.info("Input files:\n\t%s", "\n\t".join(infiles))
+        logger.info("Input files:\n\t%s", "\n\t".join([str(_) for _ in infiles]))
 
         # Are we subsampling? If so, make the selection here
         if args.subsample:
             infiles = subsample_input(args, logger, infiles)
-            logger.info("Sampled input files:\n\t%s", "\n\t".join(infiles))
+            logger.info("Sampled input files:\n\t%s", "\n\t".join([str(_) for _ in infiles]))
 
         # Get lengths of input sequences
         logger.info("Processing input sequence lengths")

--- a/pyani/scripts/delta_filter_wrapper.py
+++ b/pyani/scripts/delta_filter_wrapper.py
@@ -67,7 +67,7 @@ import subprocess
 import sys
 
 
-def run_main():
+def run_main() -> int:
     """Run main process for delta_filter_wrapper.py."""
     # Parse command-line
     df_exe = sys.argv[1]

--- a/pyani/scripts/logger.py
+++ b/pyani/scripts/logger.py
@@ -46,10 +46,11 @@ import logging
 import sys
 import time
 
+from argparse import Namespace
 from pathlib import Path
 
 
-def build_logger(name, args):
+def build_logger(name: str, args: Namespace) -> logging.Logger:
     """Return a logger for this script.
 
     :param name:  str, name for logger

--- a/pyani/scripts/parsers/__init__.py
+++ b/pyani/scripts/parsers/__init__.py
@@ -1,29 +1,34 @@
 # -*- coding: utf-8 -*-
 # (c) The James Hutton Institute 2017-2019
-#
+# (c) University of Strathclyde 2019-2020
 # Author: Leighton Pritchard
-# Contact: leighton.pritchard@hutton.ac.uk
+#
+# Contact:
+# leighton.pritchard@strath.ac.uk
+#
 # Leighton Pritchard,
-# Information and Computing Sciences,
-# James Hutton Institute,
-# Errol Road,
-# Invergowrie,
-# Dundee,
-# DD6 9LH,
+# Strathclyde Institute for Pharmacy and Biomedical Sciences,
+# Cathedral Street,
+# Glasgow,
+# G4 0RE
 # Scotland,
 # UK
 #
 # The MIT License
 #
 # Copyright (c) 2017-2019 The James Hutton Institute
+# Copyright (c) 2019-2020 University of Strathclyde
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/pyani/scripts/parsers/__init__.py
+++ b/pyani/scripts/parsers/__init__.py
@@ -35,7 +35,8 @@
 
 import sys
 
-from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter, Namespace
+from typing import List, Optional
 
 from pyani.scripts.parsers import (
     download_parser,
@@ -54,7 +55,7 @@ from pyani.scripts.parsers import (
 
 
 # Process command-line
-def parse_cmdline(argv=None):
+def parse_cmdline(argv: Optional[List] = None) -> Namespace:
     """Parse command-line arguments for script.
 
     :param argv:  Namespace, command-line arguments

--- a/pyani/scripts/parsers/anib_parser.py
+++ b/pyani/scripts/parsers/anib_parser.py
@@ -1,23 +1,23 @@
 # -*- coding: utf-8 -*-
 # (c) The James Hutton Institute 2016-2019
+# (c) University of Strathclyde 2019-2020
 # Author: Leighton Pritchard
 #
 # Contact:
-# leighton.pritchard@hutton.ac.uk
+# leighton.pritchard@strath.ac.uk
 #
 # Leighton Pritchard,
-# Information and Computing Sciences,
-# James Hutton Institute,
-# Errol Road,
-# Invergowrie,
-# Dundee,
-# DD2 5DA,
+# Strathclyde Institute for Pharmacy and Biomedical Sciences,
+# Cathedral Street,
+# Glasgow,
+# G4 0RE
 # Scotland,
 # UK
 #
 # The MIT License
 #
 # Copyright (c) 2016-2019 The James Hutton Institute
+# Copyright (c) 2019-2020 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pyani/scripts/parsers/anib_parser.py
+++ b/pyani/scripts/parsers/anib_parser.py
@@ -38,14 +38,17 @@
 # THE SOFTWARE.
 """Provides parser for anib subcommand."""
 
-from argparse import ArgumentDefaultsHelpFormatter
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, _SubParsersAction
 from pathlib import Path
+from typing import List, Optional
 
 from pyani import pyani_config
 from pyani.scripts import subcommands
 
 
-def build(subps, parents=None):
+def build(
+    subps: _SubParsersAction, parents: Optional[List[ArgumentParser]] = None
+) -> None:
     """Return a command-line parser for the anib subcommand.
 
     :param subps:  collection of subparsers in main parser

--- a/pyani/scripts/parsers/aniblastall_parser.py
+++ b/pyani/scripts/parsers/aniblastall_parser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # (c) The James Hutton Institute 2016-2019
-# (c) University of Strathclyde 2019
+# (c) University of Strathclyde 2019-2020
 # Author: Leighton Pritchard
 #
 # Contact:
@@ -10,14 +10,14 @@
 # Strathclyde Institute for Pharmacy and Biomedical Sciences,
 # Cathedral Street,
 # Glasgow,
-# G1 1XQ
+# G4 0RE
 # Scotland,
 # UK
 #
 # The MIT License
 #
 # Copyright (c) 2016-2019 The James Hutton Institute
-# Copyright (c) 2019 University of Strathclyde
+# Copyright (c) 2019-2020 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pyani/scripts/parsers/aniblastall_parser.py
+++ b/pyani/scripts/parsers/aniblastall_parser.py
@@ -38,12 +38,15 @@
 # THE SOFTWARE.
 """Provides parser for aniblastall subcommand."""
 
-from argparse import ArgumentDefaultsHelpFormatter
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, _SubParsersAction
+from typing import List, Optional
 
 from pyani.scripts import subcommands
 
 
-def build(subps, parents=None):
+def build(
+    subps: _SubParsersAction, parents: Optional[List[ArgumentParser]] = None
+) -> None:
     """Return a command-line parser for the aniblastall subcommand.
 
     :param subps:  collection of subparsers in main parser

--- a/pyani/scripts/parsers/anim_parser.py
+++ b/pyani/scripts/parsers/anim_parser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # (c) The James Hutton Institute 2016-2019
-# (c) University of Strathclyde 2019
+# (c) University of Strathclyde 2019-2020
 # Author: Leighton Pritchard
 #
 # Contact:
@@ -10,14 +10,14 @@
 # Strathclyde Institute for Pharmacy and Biomedical Sciences,
 # Cathedral Street,
 # Glasgow,
-# G1 1XQ
+# G4 0RE
 # Scotland,
 # UK
 #
 # The MIT License
 #
 # Copyright (c) 2016-2019 The James Hutton Institute
-# Copyright (c) 2019 University of Strathclyde
+# Copyright (c) 2019-2020 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pyani/scripts/parsers/anim_parser.py
+++ b/pyani/scripts/parsers/anim_parser.py
@@ -38,14 +38,17 @@
 # THE SOFTWARE.
 """Provides parser for anim subcommand."""
 
-from argparse import ArgumentDefaultsHelpFormatter
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, _SubParsersAction
 from pathlib import Path
+from typing import List, Optional
 
 from pyani import pyani_config
 from pyani.scripts import subcommands
 
 
-def build(subps, parents=None):
+def build(
+    subps: _SubParsersAction, parents: Optional[List[ArgumentParser]] = None
+) -> None:
     """Return a command-line parser for the anim subcommand.
 
     :param subps:  collection of subparsers in main parser

--- a/pyani/scripts/parsers/classify_parser.py
+++ b/pyani/scripts/parsers/classify_parser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # (c) The James Hutton Institute 2016-2019
-# (c) University of Strathclyde 2019
+# (c) University of Strathclyde 2019-2020
 # Author: Leighton Pritchard
 #
 # Contact:
@@ -10,14 +10,14 @@
 # Strathclyde Institute for Pharmacy and Biomedical Sciences,
 # Cathedral Street,
 # Glasgow,
-# G1 1XQ
+# G4 0RE
 # Scotland,
 # UK
 #
 # The MIT License
 #
 # Copyright (c) 2016-2019 The James Hutton Institute
-# Copyright (c) 2019 University of Strathclyde
+# Copyright (c) 2019-2020 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pyani/scripts/parsers/classify_parser.py
+++ b/pyani/scripts/parsers/classify_parser.py
@@ -38,13 +38,16 @@
 # THE SOFTWARE.
 """Provides parser for classify subcommand."""
 
-from argparse import ArgumentDefaultsHelpFormatter
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, _SubParsersAction
 from pathlib import Path
+from typing import List, Optional
 
 from pyani.scripts import subcommands
 
 
-def build(subps, parents=None):
+def build(
+    subps: _SubParsersAction, parents: Optional[List[ArgumentParser]] = None
+) -> None:
     """Return a command-line parser for the classify subcommand.
 
     :param subps:  collection of subparsers in main parser

--- a/pyani/scripts/parsers/common_parser.py
+++ b/pyani/scripts/parsers/common_parser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # (c) The James Hutton Institute 2016-2019
-# (c) University of Strathclyde 2019
+# (c) University of Strathclyde 2019-2020
 # Author: Leighton Pritchard
 #
 # Contact:
@@ -10,14 +10,14 @@
 # Strathclyde Institute for Pharmacy and Biomedical Sciences,
 # Cathedral Street,
 # Glasgow,
-# G1 1XQ
+# G4 0RE
 # Scotland,
 # UK
 #
 # The MIT License
 #
 # Copyright (c) 2016-2019 The James Hutton Institute
-# Copyright (c) 2019 University of Strathclyde
+# Copyright (c) 2019-2020 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pyani/scripts/parsers/common_parser.py
+++ b/pyani/scripts/parsers/common_parser.py
@@ -44,7 +44,7 @@ from pathlib import Path
 
 
 # Common parser for all subcommands
-def build():
+def build() -> ArgumentParser:
     """Return the common argument parser for all script subcommands.
 
     :param subps:  collection of subparsers in main parser

--- a/pyani/scripts/parsers/createdb_parser.py
+++ b/pyani/scripts/parsers/createdb_parser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # (c) The James Hutton Institute 2016-2019
-# (c) University of Strathclyde 2019
+# (c) University of Strathclyde 2019-2020
 # Author: Leighton Pritchard
 #
 # Contact:
@@ -10,14 +10,14 @@
 # Strathclyde Institute for Pharmacy and Biomedical Sciences,
 # Cathedral Street,
 # Glasgow,
-# G1 1XQ
+# G4 0RE
 # Scotland,
 # UK
 #
 # The MIT License
 #
 # Copyright (c) 2016-2019 The James Hutton Institute
-# Copyright (c) 2019 University of Strathclyde
+# Copyright (c) 2019-2020 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pyani/scripts/parsers/createdb_parser.py
+++ b/pyani/scripts/parsers/createdb_parser.py
@@ -38,13 +38,16 @@
 # THE SOFTWARE.
 """Provides parser for createdb subcommand."""
 
-from argparse import ArgumentDefaultsHelpFormatter
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, _SubParsersAction
 from pathlib import Path
+from typing import List, Optional
 
 from pyani.scripts import subcommands
 
 
-def build(subps, parents=None):
+def build(
+    subps: _SubParsersAction, parents: Optional[List[ArgumentParser]] = None
+) -> None:
     """Return a command-line parser for the createdb subcommand.
 
     :param subps:  collection of subparsers in main parser

--- a/pyani/scripts/parsers/download_parser.py
+++ b/pyani/scripts/parsers/download_parser.py
@@ -38,14 +38,17 @@
 # THE SOFTWARE.
 """Provides parser for download subcommand."""
 
-from argparse import ArgumentDefaultsHelpFormatter
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, _SubParsersAction
 from pathlib import Path
+from typing import List, Optional
 
 from pyani.scripts import subcommands
 
 
 # Subcommand parsers
-def build(subps, parents=None):
+def build(
+    subps: _SubParsersAction, parents: Optional[List[ArgumentParser]] = None
+) -> None:
     """Return a command-line parser for the download subcommand.
 
     :param subps:  ArgumentParser.subparser

--- a/pyani/scripts/parsers/download_parser.py
+++ b/pyani/scripts/parsers/download_parser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # (c) The James Hutton Institute 2016-2019
-# (c) University of Strathclyde 2019
+# (c) University of Strathclyde 2019-2020
 # Author: Leighton Pritchard
 #
 # Contact:
@@ -10,14 +10,14 @@
 # Strathclyde Institute for Pharmacy and Biomedical Sciences,
 # Cathedral Street,
 # Glasgow,
-# G1 1XQ
+# G4 0RE
 # Scotland,
 # UK
 #
 # The MIT License
 #
 # Copyright (c) 2016-2019 The James Hutton Institute
-# Copyright (c) 2019 University of Strathclyde
+# Copyright (c) 2019-2020 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pyani/scripts/parsers/index_parser.py
+++ b/pyani/scripts/parsers/index_parser.py
@@ -38,13 +38,16 @@
 # THE SOFTWARE.
 """Provides parser for index subcommand."""
 
-from argparse import ArgumentDefaultsHelpFormatter
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, _SubParsersAction
 from pathlib import Path
+from typing import List, Optional
 
 from pyani.scripts import subcommands
 
 
-def build(subps, parents=None):
+def build(
+    subps: _SubParsersAction, parents: Optional[List[ArgumentParser]] = None
+) -> None:
     """Return a command-line parser for the index subcommand.
 
     :param subps:  collection of subparsers in main parser

--- a/pyani/scripts/parsers/index_parser.py
+++ b/pyani/scripts/parsers/index_parser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # (c) The James Hutton Institute 2016-2019
-# (c) University of Strathclyde 2019
+# (c) University of Strathclyde 2019-2020
 # Author: Leighton Pritchard
 #
 # Contact:
@@ -10,14 +10,14 @@
 # Strathclyde Institute for Pharmacy and Biomedical Sciences,
 # Cathedral Street,
 # Glasgow,
-# G1 1XQ
+# G4 0RE
 # Scotland,
 # UK
 #
 # The MIT License
 #
 # Copyright (c) 2016-2019 The James Hutton Institute
-# Copyright (c) 2019 University of Strathclyde
+# Copyright (c) 2019-2020 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pyani/scripts/parsers/plot_parser.py
+++ b/pyani/scripts/parsers/plot_parser.py
@@ -38,13 +38,16 @@
 # THE SOFTWARE.
 """Provides parser for plot subcommand."""
 
-from argparse import ArgumentDefaultsHelpFormatter
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, _SubParsersAction
 from pathlib import Path
+from typing import List, Optional
 
 from pyani.scripts import subcommands
 
 
-def build(subps, parents=None):
+def build(
+    subps: _SubParsersAction, parents: Optional[List[ArgumentParser]] = None
+) -> None:
     """Return a command-line parser for the plot subcommand.
 
     :param subps:  collection of subparsers in main parser

--- a/pyani/scripts/parsers/plot_parser.py
+++ b/pyani/scripts/parsers/plot_parser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # (c) The James Hutton Institute 2016-2019
-# (c) University of Strathclyde 2019
+# (c) University of Strathclyde 2019-2020
 # Author: Leighton Pritchard
 #
 # Contact:
@@ -10,14 +10,14 @@
 # Strathclyde Institute for Pharmacy and Biomedical Sciences,
 # Cathedral Street,
 # Glasgow,
-# G1 1XQ
+# G4 0RE
 # Scotland,
 # UK
 #
 # The MIT License
 #
 # Copyright (c) 2016-2019 The James Hutton Institute
-# Copyright (c) 2019 University of Strathclyde
+# Copyright (c) 2019-2020 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pyani/scripts/parsers/report_parser.py
+++ b/pyani/scripts/parsers/report_parser.py
@@ -38,13 +38,14 @@
 # THE SOFTWARE.
 """Provides parser for report subcommand."""
 
-from argparse import ArgumentDefaultsHelpFormatter
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, _SubParsersAction
 from pathlib import Path
+from typing import List, Optional
 
 from pyani.scripts import subcommands
 
 
-def build(subps, parents=None):
+def build(subps: _SubParsersAction, parents: Optional[List[ArgumentParser]]=None) -> None:
     """Return a command-line parser for the report subcommand.
 
     :param subps:  collection of subparsers in main parser

--- a/pyani/scripts/parsers/report_parser.py
+++ b/pyani/scripts/parsers/report_parser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # (c) The James Hutton Institute 2016-2019
-# (c) University of Strathclyde 2019
+# (c) University of Strathclyde 2019-2020
 # Author: Leighton Pritchard
 #
 # Contact:
@@ -10,14 +10,14 @@
 # Strathclyde Institute for Pharmacy and Biomedical Sciences,
 # Cathedral Street,
 # Glasgow,
-# G1 1XQ
+# G4 0RE
 # Scotland,
 # UK
 #
 # The MIT License
 #
 # Copyright (c) 2016-2019 The James Hutton Institute
-# Copyright (c) 2019 University of Strathclyde
+# Copyright (c) 2019-2020 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -45,7 +45,9 @@ from typing import List, Optional
 from pyani.scripts import subcommands
 
 
-def build(subps: _SubParsersAction, parents: Optional[List[ArgumentParser]]=None) -> None:
+def build(
+    subps: _SubParsersAction, parents: Optional[List[ArgumentParser]] = None
+) -> None:
     """Return a command-line parser for the report subcommand.
 
     :param subps:  collection of subparsers in main parser

--- a/pyani/scripts/parsers/run_common_parser.py
+++ b/pyani/scripts/parsers/run_common_parser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # (c) The James Hutton Institute 2016-2019
-# (c) University of Strathclyde 2019
+# (c) University of Strathclyde 2019-2020
 # Author: Leighton Pritchard
 #
 # Contact:
@@ -10,14 +10,14 @@
 # Strathclyde Institute for Pharmacy and Biomedical Sciences,
 # Cathedral Street,
 # Glasgow,
-# G1 1XQ
+# G4 0RE
 # Scotland,
 # UK
 #
 # The MIT License
 #
 # Copyright (c) 2016-2019 The James Hutton Institute
-# Copyright (c) 2019 University of Strathclyde
+# Copyright (c) 2019-2020 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pyani/scripts/parsers/run_common_parser.py
+++ b/pyani/scripts/parsers/run_common_parser.py
@@ -43,7 +43,7 @@ from pathlib import Path
 
 
 # Common parser for all subcommands
-def build():
+def build() -> ArgumentParser:
     """Return the common argument parser for analysis run subcommands.
 
     :param subps:  collection of subparsers in main parser

--- a/pyani/scripts/parsers/scheduling_parser.py
+++ b/pyani/scripts/parsers/scheduling_parser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # (c) The James Hutton Institute 2016-2019
-# (c) University of Strathclyde 2019
+# (c) University of Strathclyde 2019-2020
 # Author: Leighton Pritchard
 #
 # Contact:
@@ -10,14 +10,14 @@
 # Strathclyde Institute for Pharmacy and Biomedical Sciences,
 # Cathedral Street,
 # Glasgow,
-# G1 1XQ
+# G4 0RE
 # Scotland,
 # UK
 #
 # The MIT License
 #
 # Copyright (c) 2016-2019 The James Hutton Institute
-# Copyright (c) 2019 University of Strathclyde
+# Copyright (c) 2019-2020 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pyani/scripts/parsers/scheduling_parser.py
+++ b/pyani/scripts/parsers/scheduling_parser.py
@@ -41,7 +41,7 @@
 from argparse import ArgumentParser
 
 
-def build():
+def build() -> ArgumentParser:
     """Return the common argument parser for job scheduling.
 
     :param subps:  collection of subparsers in main parser

--- a/pyani/scripts/pyani_script.py
+++ b/pyani/scripts/pyani_script.py
@@ -42,13 +42,16 @@
 import sys
 import time
 
+from logging import Logger
+from typing import List, Optional
+
 from .logger import build_logger
 from .parsers import parse_cmdline
 from .. import __version__
 
 
 # Main function
-def run_main(argv=None, logger=None):
+def run_main(argv: Optional[List[str]] = None, logger: Optional[Logger] = None) -> int:
     """Run main process for pyani.py script.
 
     :param argv:

--- a/pyani/scripts/subcommands/subcmd_anib.py
+++ b/pyani/scripts/subcommands/subcmd_anib.py
@@ -42,8 +42,11 @@ import datetime
 import json
 import os
 
+from argparse import Namespace
 from itertools import permutations
+from logging import Logger
 from pathlib import Path
+from typing import List, Tuple
 
 from Bio import SeqIO
 from tqdm import tqdm
@@ -60,7 +63,7 @@ from pyani.pyani_orm import (
 )
 
 
-def subcmd_anib(args, logger):
+def subcmd_anib(args: Namespace, logger: Logger) -> None:
     """Perform ANIb on all genome files in an input directory.
 
     :param args:  Namespace, command-line arguments
@@ -235,7 +238,14 @@ def subcmd_anib(args, logger):
     raise NotImplementedError
 
 
-def generate_joblist(comparisons, existingfiles, fragfiles, fraglens, args, logger):
+def generate_joblist(
+    comparisons: List,
+    existingfiles: List,
+    fragfiles: List,
+    fraglens: List,
+    args: Namespace,
+    logger: Logger,
+) -> NotImplementedError:
     """Return list of ComparisonJobs.
 
     :param comparisons:  list of (Genome, Genome) tuples for which comparisons are needed
@@ -248,7 +258,7 @@ def generate_joblist(comparisons, existingfiles, fragfiles, fraglens, args, logg
     raise NotImplementedError
 
 
-def fragment_fasta_file(inpath, outdir, fragsize):
+def fragment_fasta_file(inpath: Path, outdir: Path, fragsize: int) -> Tuple[Path, str]:
     """Return path to fragmented sequence file and JSON of fragment lengths.
 
     :param inpath:  Path to genome file

--- a/pyani/scripts/subcommands/subcmd_aniblastall.py
+++ b/pyani/scripts/subcommands/subcmd_aniblastall.py
@@ -39,8 +39,11 @@
 # THE SOFTWARE.
 """Provides the aniblastall subcommand for pyani."""
 
+from argparse import Namespace
+from logging import Logger
 
-def subcmd_aniblastall(args, logger):
+
+def subcmd_aniblastall(args: Namespace, logger: Logger):
     """Perform ANIblastall on all genome files in an input directory.
 
     :param args:

--- a/pyani/scripts/subcommands/subcmd_anim.py
+++ b/pyani/scripts/subcommands/subcmd_anim.py
@@ -377,7 +377,7 @@ def run_anim_jobs(joblist: List[ComparisonJob], args: Namespace, logger: Logger)
         )
 
 
-def update_comparison_results(joblist: List[ComparisonJob], run, session, nucmer_version: str, args: Namespace, logger: Logger) -> NotImplementedError:
+def update_comparison_results(joblist: List[ComparisonJob], run, session, nucmer_version: str, args: Namespace, logger: Logger) -> None:
     """Update the Comparison table with the completed result set.
 
     :param joblist:         list of ComparisonJob namedtuples

--- a/pyani/scripts/subcommands/subcmd_anim.py
+++ b/pyani/scripts/subcommands/subcmd_anim.py
@@ -342,7 +342,9 @@ def generate_joblist(
     return joblist
 
 
-def run_anim_jobs(joblist: List[ComparisonJob], args: Namespace, logger: Logger) -> None:
+def run_anim_jobs(
+    joblist: List[ComparisonJob], args: Namespace, logger: Logger
+) -> None:
     """Pass ANIm nucmer jobs to the scheduler.
 
     :param joblist:           list of ComparisonJob namedtuples
@@ -377,7 +379,14 @@ def run_anim_jobs(joblist: List[ComparisonJob], args: Namespace, logger: Logger)
         )
 
 
-def update_comparison_results(joblist: List[ComparisonJob], run, session, nucmer_version: str, args: Namespace, logger: Logger) -> None:
+def update_comparison_results(
+    joblist: List[ComparisonJob],
+    run,
+    session,
+    nucmer_version: str,
+    args: Namespace,
+    logger: Logger,
+) -> None:
     """Update the Comparison table with the completed result set.
 
     :param joblist:         list of ComparisonJob namedtuples

--- a/pyani/scripts/subcommands/subcmd_createdb.py
+++ b/pyani/scripts/subcommands/subcmd_createdb.py
@@ -39,11 +39,13 @@
 # THE SOFTWARE.
 """Provides the createdb subcommand for pyani."""
 
-# from pyani import pyani_db
+from argparse import Namespace
+from logging import Logger
+
 from pyani import pyani_orm
 
 
-def subcmd_createdb(args, logger):
+def subcmd_createdb(args: Namespace, logger: Logger) -> int:
     """Create an empty pyani database.
 
     :param args:  Namespace, command-line arguments
@@ -65,3 +67,5 @@ def subcmd_createdb(args, logger):
     # Create the empty database
     logger.info("Creating pyani database at %s", args.dbpath)
     pyani_orm.create_db(args.dbpath)
+
+    return 0

--- a/pyani/scripts/subcommands/subcmd_download.py
+++ b/pyani/scripts/subcommands/subcmd_download.py
@@ -40,14 +40,21 @@
 """Provides the download subcommand for pyani."""
 
 from collections import namedtuple
+from typing import NamedTuple
 
 from Bio import SeqIO
 
 from pyani import download
 from pyani.scripts import tools
 
-# Convenience struct for file download data
-DLFileData = namedtuple("DLFileData", "filestem ftpstem suffix")
+
+class DLFileData(NamedTuple):
+
+    """Convenience struct for file download data."""
+
+    filestem: str
+    ftpstem: str
+    suffix: str
 
 
 def subcmd_download(args, logger):

--- a/pyani/scripts/subcommands/subcmd_download.py
+++ b/pyani/scripts/subcommands/subcmd_download.py
@@ -41,6 +41,7 @@
 
 from argparse import Namespace
 from collections import namedtuple
+from logging import Logger
 from typing import NamedTuple
 
 from Bio import SeqIO

--- a/pyani/scripts/subcommands/subcmd_download.py
+++ b/pyani/scripts/subcommands/subcmd_download.py
@@ -42,21 +42,11 @@
 from argparse import Namespace
 from collections import namedtuple
 from logging import Logger
-from typing import NamedTuple
 
 from Bio import SeqIO
 
 from pyani import download
 from pyani.scripts import tools
-
-
-class DLFileData(NamedTuple):
-
-    """Convenience struct for file download data."""
-
-    filestem: str
-    ftpstem: str
-    suffix: str
 
 
 def subcmd_download(args: Namespace, logger: Logger) -> int:
@@ -140,7 +130,7 @@ def subcmd_download(args: Namespace, logger: Logger) -> int:
 
             # Obtain URLs, trying the RefSeq filestem first, then GenBank if
             # there's a failure
-            dlfiledata = DLFileData(
+            dlfiledata = tools.DLFileData(
                 filestem, "ftp://ftp.ncbi.nlm.nih.gov/genomes/all", "genomic.fna.gz"
             )
             logger.info(f"Retrieving URLs for {filestem}")

--- a/pyani/scripts/subcommands/subcmd_download.py
+++ b/pyani/scripts/subcommands/subcmd_download.py
@@ -42,21 +42,11 @@
 from argparse import Namespace
 from collections import namedtuple
 from logging import Logger
-from typing import NamedTuple
 
 from Bio import SeqIO
 
 from pyani import download
 from pyani.scripts import tools
-
-
-class DLFileData(NamedTuple):
-
-    """Convenience struct for file download data."""
-
-    filestem: str
-    ftpstem: str
-    suffix: str
 
 
 def subcmd_download(args: Namespace, logger: Logger) -> int:

--- a/pyani/scripts/subcommands/subcmd_download.py
+++ b/pyani/scripts/subcommands/subcmd_download.py
@@ -39,7 +39,9 @@
 # THE SOFTWARE.
 """Provides the download subcommand for pyani."""
 
+from argparse import Namespace
 from collections import namedtuple
+from logging import Logger
 from typing import NamedTuple
 
 from Bio import SeqIO
@@ -57,7 +59,7 @@ class DLFileData(NamedTuple):
     suffix: str
 
 
-def subcmd_download(args, logger):
+def subcmd_download(args: Namespace, logger: Logger) -> int:
     """Download assembled genomes in subtree of passed NCBI taxon ID.
 
     :param args:  Namespace, command-line arguments
@@ -265,3 +267,5 @@ def subcmd_download(args, logger):
                 ]
             )
             logger.warning(f"{skipped.organism} {skipped.strain}:\n\t{outstr}")
+
+    return 0

--- a/pyani/scripts/subcommands/subcmd_download.py
+++ b/pyani/scripts/subcommands/subcmd_download.py
@@ -41,12 +41,21 @@
 
 from argparse import Namespace
 from collections import namedtuple
-from logging import Logger
+from typing import NamedTuple
 
 from Bio import SeqIO
 
 from pyani import download
 from pyani.scripts import tools
+
+
+class DLFileData(NamedTuple):
+
+    """Convenience struct for file download data."""
+
+    filestem: str
+    ftpstem: str
+    suffix: str
 
 
 def subcmd_download(args: Namespace, logger: Logger) -> int:

--- a/pyani/scripts/subcommands/subcmd_index.py
+++ b/pyani/scripts/subcommands/subcmd_index.py
@@ -39,12 +39,15 @@
 # THE SOFTWARE.
 """Provides the index subcommand for pyani."""
 
+from argparse import Namespace
+from logging import Logger
+
 from Bio import SeqIO
 
 from pyani import download, pyani_files
 
 
-def subcmd_index(args, logger):
+def subcmd_index(args: Namespace, logger: Logger) -> int:
     """Generate a file with the MD5 hash for each genome in an input directory.
 
     :param args:  Namespace, received command-line arguments
@@ -101,3 +104,5 @@ def subcmd_index(args, logger):
     else:
         with open(labelfname, "w") as ofh:
             ofh.write("\n".join(labels) + "\n")
+
+    return 0

--- a/pyani/scripts/subcommands/subcmd_plot.py
+++ b/pyani/scripts/subcommands/subcmd_plot.py
@@ -42,7 +42,10 @@
 
 import os
 
+from argparse import Namespace
+from logging import Logger
 from pathlib import Path
+from typing import Dict, List
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -60,7 +63,7 @@ DISTMETHODS = {
 }
 
 
-def subcmd_plot(args, logger):
+def subcmd_plot(args: Namespace, logger: Logger) -> int:
     """Produce graphical output for an analysis.
 
     :param args:  Namespace of command-line arguments
@@ -89,8 +92,12 @@ def subcmd_plot(args, logger):
     for run_id in run_ids:
         write_run_heatmaps(run_id, session, outfmts, args, logger)
 
+    return 0
 
-def write_run_heatmaps(run_id, session, outfmts, args, logger):
+
+def write_run_heatmaps(
+    run_id: int, session, outfmts: List[str], args: Namespace, logger: Logger
+) -> None:
     """Write all heatmaps for a specified run to file.
 
     :param run_id:  int, run identifier in database session
@@ -125,7 +132,13 @@ def write_run_heatmaps(run_id, session, outfmts, args, logger):
         write_distribution(run_id, matdata, outfmts, args, logger)
 
 
-def write_distribution(run_id, matdata, outfmts, args, logger):
+def write_distribution(
+    run_id: int,
+    matdata: MatrixData,
+    outfmts: List[str],
+    args: Namespace,
+    logger: Logger,
+) -> None:
     """Write distribution plots for each matrix type.
 
     :param run_id:  int, run_id for this run
@@ -147,8 +160,14 @@ def write_distribution(run_id, matdata, outfmts, args, logger):
 
 
 def write_heatmap(
-    run_id, matdata, result_labels, result_classes, outfmts, args, logger
-):
+    run_id: int,
+    matdata: MatrixData,
+    result_labels: Dict,
+    result_classes: Dict,
+    outfmts: List[str],
+    args: Namespace,
+    logger: Logger,
+) -> None:
     """Write a single heatmap for a pyani run.
 
     :param run_id:  int, run_id for this run

--- a/pyani/scripts/subcommands/subcmd_report.py
+++ b/pyani/scripts/subcommands/subcmd_report.py
@@ -40,7 +40,9 @@
 # THE SOFTWARE.
 """Provides the report subcommand for pyani."""
 
-from collections import namedtuple
+from argparse import Namespace
+from logging import Logger
+from typing import List, NamedTuple
 from pathlib import Path
 
 import pandas as pd
@@ -59,11 +61,17 @@ from pyani.pyani_orm import (
 )
 from pyani.pyani_tools import label_results_matrix, MatrixData
 
-# Convenience struct for report query/header data
-ReportParams = namedtuple("ReportParams", "name statement headers")
+
+class ReportParams(NamedTuple):
+
+    """Report query/header data."""
+
+    name: str  # name of table being reported
+    statement: str  #  SQL statement of query
+    headers: List[str]  #  Column headers for table
 
 
-def subcmd_report(args, logger):
+def subcmd_report(args: Namespace, logger: Logger) -> int:
     """Present report on ANI results and/or database contents.
 
     :param args:  Namespace, command-line arguments
@@ -292,8 +300,12 @@ def subcmd_report(args, logger):
                     **matdata.graphic_args,
                 )
 
+    return 0
 
-def report(args, logger, session, formats, params):
+
+def report(
+    args: Namespace, logger: Logger, session, formats: List[str], params: ReportParams,
+) -> None:
     """Write tabular report of pyani runs from database.
 
     :param args:  Namespace of command-line arguments
@@ -311,7 +323,7 @@ def report(args, logger, session, formats, params):
     pyani_report.write_dbtable(data, outfname, formats)
 
 
-def process_formats(args):
+def process_formats(args: Namespace) -> List[str]:
     """Return processed list of output formats for writing reports.
 
     :param args:  Namespace of command-line arguments

--- a/pyani/scripts/tools.py
+++ b/pyani/scripts/tools.py
@@ -91,14 +91,13 @@ def make_outdir(outdir: Path, force: bool, noclobber: bool, logger: Logger) -> N
         if force and not noclobber:  # user forces directory reuse, and overwrite
             # Delete old directory and start again
             logger.warning(
-                "Overwrite forced. Removing %s and everything " + "below it (--force)",
+                "Overwrite forced. Removing %s and everything below it (--force)",
                 outdir,
             )
             shutil.rmtree(outdir)
         elif force and noclobber:  # user forces directory reuse, not file overwrite
             logger.warning(
-                "Keeping existing directory, skipping existing "
-                + "files (--force --noclobber)."
+                "Keeping existing directory, skipping existing files (--force --noclobber)."
             )
         else:  # user is not forcing directory reuse
             raise PyaniScriptException(

--- a/pyani/scripts/tools.py
+++ b/pyani/scripts/tools.py
@@ -44,12 +44,11 @@ import shutil
 from argparse import Namespace
 from logging import Logger
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, NamedTuple
 
 from namedlist import namedlist
 
 from pyani import download
-from pyani.scripts.subcommands.subcmd_download import DLFileData
 
 
 # EXCEPTIONS
@@ -62,6 +61,15 @@ class PyaniScriptException(Exception):
     def __init__(self, msg="Error in pyani.py script"):
         """Insantiate exception."""
         Exception.__init__(self, msg)
+
+
+class DLFileData(NamedTuple):
+
+    """Convenience struct for file download data."""
+
+    filestem: str
+    ftpstem: str
+    suffix: str
 
 
 # UTILITY FUNCTIONS

--- a/pyani/scripts/tools.py
+++ b/pyani/scripts/tools.py
@@ -49,7 +49,7 @@ from typing import Dict, List
 from namedlist import namedlist
 
 from pyani import download
-from .subcommands.subcmd_download import DLFileData
+from pyani.subcommands.subcmd_download import DLFileData
 
 
 # EXCEPTIONS

--- a/pyani/scripts/tools.py
+++ b/pyani/scripts/tools.py
@@ -44,11 +44,16 @@ import shutil
 from argparse import Namespace
 from logging import Logger
 from pathlib import Path
+<<<<<<< HEAD
 from typing import Dict, List, NamedTuple
+=======
+from typing import Dict, List
+>>>>>>> add static typing hints to tools.py
 
 from namedlist import namedlist
 
 from pyani import download
+from .subcommands.subcmd_download import DLFileData
 
 
 # EXCEPTIONS

--- a/pyani/scripts/tools.py
+++ b/pyani/scripts/tools.py
@@ -49,7 +49,7 @@ from typing import Dict, List, NamedTuple
 from namedlist import namedlist
 
 from pyani import download
-from pyani.subcommands.subcmd_download import DLFileData
+from pyani.scripts.subcommands.subcmd_download import DLFileData
 
 
 # EXCEPTIONS

--- a/pyani/scripts/tools.py
+++ b/pyani/scripts/tools.py
@@ -41,7 +41,15 @@
 import re
 import shutil
 
+from argparse import Namespace
+from logging import Logger
+from pathlib import Path
+from typing import Dict, List
+
+from namedlist import namedlist
+
 from pyani import download
+from .subcommands.subcmd_download import DLFileData
 
 
 # EXCEPTIONS
@@ -60,7 +68,7 @@ class PyaniScriptException(Exception):
 # =================
 
 # Create a directory (handling force/noclobber options)
-def make_outdir(outdir, force, noclobber, logger):
+def make_outdir(outdir: Path, force: bool, noclobber: bool, logger: Logger) -> None:
     """Create output directory (allows for force and noclobber).
 
     :param outdir:  Path, path to output directory
@@ -100,7 +108,7 @@ def make_outdir(outdir, force, noclobber, logger):
 
 
 # Make a dictionary of assembly download info
-def make_asm_dict(taxon_ids, retries):
+def make_asm_dict(taxon_ids: List[str], retries: int) -> Dict:
     """Return a dict of assembly UIDs, keyed by each passed taxon ID.
 
     :param taxon_ids:
@@ -117,8 +125,12 @@ def make_asm_dict(taxon_ids, retries):
 
 # Download the RefSeq genome and MD5 hash from NCBI
 def download_genome_and_hash(
-    args, logger, dlfiledata, dltype="RefSeq", disable_tqdm=False
-):
+    args: Namespace,
+    logger: Logger,
+    dlfiledata: DLFileData,
+    dltype: str = "RefSeq",
+    disable_tqdm: bool = False,
+) -> namedlist:
     """Download genome and accompanying MD5 hash from NCBI.
 
     :param args:  Namespace for command-line arguments

--- a/pyani/scripts/tools.py
+++ b/pyani/scripts/tools.py
@@ -49,7 +49,6 @@ from typing import Dict, List, NamedTuple
 from namedlist import namedlist
 
 from pyani import download
-from pyani.scripts.subcommands.subcmd_download import DLFileData
 
 
 # EXCEPTIONS

--- a/pyani/scripts/tools.py
+++ b/pyani/scripts/tools.py
@@ -44,11 +44,7 @@ import shutil
 from argparse import Namespace
 from logging import Logger
 from pathlib import Path
-<<<<<<< HEAD
 from typing import Dict, List, NamedTuple
-=======
-from typing import Dict, List
->>>>>>> add static typing hints to tools.py
 
 from namedlist import namedlist
 

--- a/pyani/scripts/tools.py
+++ b/pyani/scripts/tools.py
@@ -49,7 +49,7 @@ from typing import Dict, List
 from namedlist import namedlist
 
 from pyani import download
-from pyani.subcommands.subcmd_download import DLFileData
+from pyani.scripts.subcommands.subcmd_download import DLFileData
 
 
 # EXCEPTIONS

--- a/pyani/scripts/tools.py
+++ b/pyani/scripts/tools.py
@@ -49,7 +49,7 @@ from typing import Dict, List, NamedTuple
 from namedlist import namedlist
 
 from pyani import download
-from .subcommands.subcmd_download import DLFileData
+from pyani.subcommands.subcmd_download import DLFileData
 
 
 # EXCEPTIONS

--- a/pyani/tetra.py
+++ b/pyani/tetra.py
@@ -57,9 +57,9 @@ import math
 from pathlib import Path
 from typing import Dict, Iterable, Tuple
 
-import pandas as pd
+import pandas as pd  # type: ignore
 
-from Bio import SeqIO
+from Bio import SeqIO  # type: ignore
 
 
 # Calculate tetranucleotide Z-score for a set of input sequences

--- a/pyani/tetra.py
+++ b/pyani/tetra.py
@@ -54,25 +54,28 @@ doi:10.1111/j.1462-2920.2004.00624.x
 import collections
 import math
 
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
+
 import pandas as pd
 
 from Bio import SeqIO
 
 
 # Calculate tetranucleotide Z-score for a set of input sequences
-def calculate_tetra_zscores(infilenames):
+def calculate_tetra_zscores(infilenames: Iterable) -> Dict[str, Dict[str, float]]:
     """Return dictionary of TETRA Z-scores for each input file.
 
     :param infilenames:  iterable of paths to input sequence files
     """
-    org_tetraz = {}
+    org_tetraz = {}  # type: Dict[str, Dict[str, float]]
     for filename in infilenames:
         org_tetraz[filename.stem] = calculate_tetra_zscore(filename)
     return org_tetraz
 
 
 # Calculate tetranucleotide Z-score for a single sequence file
-def calculate_tetra_zscore(filename):
+def calculate_tetra_zscore(filename: Path) -> Dict[str, float]:
     """Return TETRA Z-score for the sequence in the passed file.
 
     :param filename:  path to sequence file
@@ -91,7 +94,7 @@ def calculate_tetra_zscore(filename):
         collections.defaultdict(int),
         collections.defaultdict(int),
         collections.defaultdict(int),
-    )
+    )  # type: Tuple
     for rec in SeqIO.parse(filename, "fasta"):
         for seq in [str(rec.seq).upper(), str(rec.seq.reverse_complement()).upper()]:
             # The Teeling et al. algorithm requires us to consider
@@ -137,22 +140,22 @@ def calculate_tetra_zscore(filename):
 
 
 # Returns true if the passed string contains only A, C, G or T
-def tetra_clean(string):
+def tetra_clean(instr: str) -> bool:
     """Return True if string contains only unambiguous IUPAC nucleotide symbols.
 
-    :param string:  str, nucleotide sequence
+    :param instr:  str, nucleotide sequence
 
     We are assuming that a low frequency of IUPAC ambiguity symbols doesn't
     affect our calculation.
     """
-    if set(string) - set("ACGT"):
+    if set(instr) - set("ACGT"):
         return False
     return True
 
 
 # Calculate Pearson's correlation coefficient from the Z-scores for each
 # tetranucleotide. If we're forcing rpy2, might as well use that, though...
-def calculate_correlations(tetra_z):
+def calculate_correlations(tetra_z: Dict[str, Dict[str, float]]) -> pd.DataFrame:
     """Return dataframe of Pearson correlation coefficients.
 
     :param tetra_z:  dict, Z-scores, keyed by sequence ID

--- a/requirements-pip.txt
+++ b/requirements-pip.txt
@@ -1,4 +1,3 @@
-Pillow
 pre-commit
 pytest-ordering
 sphinx-rtd-theme

--- a/requirements-pip.txt
+++ b/requirements-pip.txt
@@ -1,3 +1,4 @@
+Pillow
 pre-commit
 pytest-ordering
 sphinx-rtd-theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ networkx
 numpy
 openpyxl
 pandas
-pillow
 scipy
 seaborn
 sqlalchemy==1.3.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
 biopython
-matplotlib
+matplotlib==3.1.0
 namedlist
 networkx
 numpy
 openpyxl
 pandas
+Pillow==6.2.1
 scipy
 seaborn
 sqlalchemy==1.3.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 biopython
-matplotlib==3.1.0
+matplotlib
 namedlist
 networkx
 numpy

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,55 +1,50 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""test_dependencies.py
-
-Tests for availability of pyani dependencies
+# (c) The James Hutton Institute 2017-2019
+# (c) The University of Strathclude 2019
+# Author: Leighton Pritchard
+#
+# Contact:
+# leighton.pritchard@strath.ac.uk
+#
+# Leighton Pritchard,
+# Strathclyde Institute of Pharmaceutical and Biomedical Sciences
+# The University of Strathclyde
+# Cathedral Street
+# Glasgow
+# G1 1XQ
+# Scotland,
+# UK
+#
+# The MIT License
+#
+# Copyright (c) 2017-2018 The James Hutton Institute
+# (c) The University of Strathclude 2019
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""Test for availability of pyani dependencies.
 
 We only test for dependencies from non-standard libraries.
 
 These tests are intended to be run from the repository root using:
 
 pytest -v
-
-print() statements will be caught by nosetests unless there is an
-error. They can also be recovered with the -s option.
-
-(c) The James Hutton Institute 2017-2019
-Author: Leighton Pritchard
-
-Contact:
-leighton.pritchard@hutton.ac.uk
-
-Leighton Pritchard,
-Information and Computing Sciences,
-James Hutton Institute,
-Errol Road,
-Invergowrie,
-Dundee,
-DD2 5DA,
-Scotland,
-UK
-
-The MIT License
-
-Copyright (c) 2017-2019 The James Hutton Institute
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
 """
 
 import subprocess
@@ -93,7 +88,7 @@ class TestDependencyExecutables(unittest.TestCase):
     def test_run_blast(self):
         """Test that BLAST+ is runnable."""
         blastn_exe = pyani_config.BLASTN_DEFAULT
-        cmd = [blastn_exe, "-version"]
+        cmd = [str(blastn_exe), "-version"]
         result = subprocess.run(
             cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True
         )
@@ -103,7 +98,7 @@ class TestDependencyExecutables(unittest.TestCase):
     def test_run_blastall(self):
         """Test that legacy BLAST is runnable."""
         blastall_exe = pyani_config.BLASTALL_DEFAULT
-        cmd = blastall_exe
+        cmd = str(blastall_exe)
         # Can't use check=True, as blastall without arguments returns 1!
         result = subprocess.run(
             cmd,
@@ -118,7 +113,7 @@ class TestDependencyExecutables(unittest.TestCase):
     def test_run_nucmer(self):
         """Test that NUCmer is runnable."""
         nucmer_exe = pyani_config.NUCMER_DEFAULT
-        cmd = [nucmer_exe, "--version"]
+        cmd = [str(nucmer_exe), "--version"]
         result = subprocess.run(
             cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True
         )


### PR DESCRIPTION
This PR adds `mypy` type hints to most of the `pyani` codebase. The most notable exception is for `SQLAlchemy` dynamic objects, which are not possible to type statically. This closes #168.