### PR TITLE
Update anim.py

### DIFF
--- a/pyani/anim.py
+++ b/pyani/anim.py
@@ -241,7 +241,7 @@ def parse_delta(filename: Path) -> Tuple[int, int]:
     - start on target
     - end on target
     - error count (non-identical, plus indels)
-    - similarity errors (non-positive match scores)
+    - similarity errors (non-positive match scores) [unless using promer this is equal to the previous]
     - stop codons (always zero for nucmer)
     """
     aln_length, sim_errors = 0, 0
@@ -251,9 +251,10 @@ def parse_delta(filename: Path) -> Tuple[int, int]:
         # We only process lines with seven columns:
         if len(line) == 7:
             aln_length += abs(int(line[1]) - int(line[0]) + 1)
-            indels = int(line[4]) - int(line[5])
-            aln_length -= indels
             sim_errors += int(line[5])
+        if len(line) == 1 and int(line[0]) < 0:
+            # Add one to the alignment length for each gap introduced in the reference
+            aln_length += 1
     return aln_length, sim_errors
 
 


### PR DESCRIPTION
The original script does not parse delta files correctly. In seven column lines, column 5 and 6 are equal when using nucmer, so the following lines do nothing.
```
            indels = int(line[4]) - int(line[5])
            aln_length -= indels
```
Delta files code gap in the reference sequence by the number of negative numbers following the 7 column line. (Query gaps are coded by the positive numbers. The absolute value of the numbers indicate how far the gap is from either the start of the alignment or the previous gap position; distance of 1 is the first following position.)

The suggested edit corrects the alignment length summed up. The sim_errors were already correctly collected.