### PR TITLE
fix #206 and remove unnecessary logger arguments to subcommands

### DIFF
--- a/pyani/scripts/subcommands/subcmd_aniblastall.py
+++ b/pyani/scripts/subcommands/subcmd_aniblastall.py
@@ -43,7 +43,7 @@ from argparse import Namespace
 from logging import Logger
 
 
-def subcmd_aniblastall(args: Namespace, logger: Logger):
+def subcmd_aniblastall(args: Namespace):
     """Perform ANIblastall on all genome files in an input directory.
 
     :param args:

--- a/pyani/scripts/subcommands/subcmd_index.py
+++ b/pyani/scripts/subcommands/subcmd_index.py
@@ -39,15 +39,16 @@
 # THE SOFTWARE.
 """Provides the index subcommand for pyani."""
 
+import logging
+
 from argparse import Namespace
-from logging import Logger
 
 from Bio import SeqIO
 
 from pyani import download, pyani_files
 
 
-def subcmd_index(args: Namespace, logger: Logger) -> int:
+def subcmd_index(args: Namespace) -> int:
     """Generate a file with the MD5 hash for each genome in an input directory.
 
     :param args:  Namespace, received command-line arguments
@@ -58,6 +59,8 @@ def subcmd_index(args: Namespace, logger: Logger) -> int:
 
     Genome files (FASTA) are identified from the file extension.
     """
+    logger = logging.getLogger(__name__)
+
     # Get list of FASTA files in the input directory
     logger.info("Scanning directory %s for FASTA files", args.indir)
     fpaths = pyani_files.get_fasta_paths(args.indir)

--- a/tests/test_subcmd_02_index.py
+++ b/tests/test_subcmd_02_index.py
@@ -83,7 +83,7 @@ class TestIndexSubcommand(unittest.TestCase):
         """Test indexing of downloaded files."""
         # Create index
         print(self.argsdict["index"])
-        subcommands.subcmd_index(self.argsdict["index"], self.logger)
+        subcommands.subcmd_index(self.argsdict["index"])
 
         # Check class and label files
         for fname in ("labels.txt", "classes.txt"):


### PR DESCRIPTION
Fixes #206 by removing the logger argument from subcmd_index().
There was a similar problem waiting in subcmd_aniblastall(), too,
so that was fixed also.