### PR TITLE
Remove obsolete comment about conda package

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,6 @@ Then install `pyani`:
 conda install pyani
 ```
 
-**NOTE:** The current `conda` version is *behind* the development version and has a different command-line interface. Documentation for the `conda` version (0.2.x) can be found at the link below:
-
-- [https://github.com/widdowquinn/pyani/blob/master/README_v_0_2_x.md](https://github.com/widdowquinn/pyani/blob/master/README_v_0_2_x.md)
-
-
 ### Installing legacy BLAST
 
 The NCBI legacy `BLAST` package is deprecated and not recommended. However, if you wish to use `pyani blastall` or the `ANIblastall` method with the legacy `pyani` interface, you will require a locally-installed copy of this package. This is one of the packages linked in the `requirements-thirdparty.txt` file.


### PR DESCRIPTION
Currently both PiPY and conda have v0.2.10