### PR TITLE
Add Python 3.8 to CircleCI matrix, and schedule weekly test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,14 +11,14 @@ workflows:
   version: 2.1
   test:
     jobs:
+      - test-3_8
       - test-3_7
       - test-3_6
-      # - test-3_8
 
 jobs:
-  test-3_7: &test-template
+  test-3_8: &test-template
     docker:
-      - image: circleci/python:3.7.5
+      - image: circleci/python:3.8.5
 
     working_directory: ~/repo
 
@@ -83,11 +83,11 @@ jobs:
       - codecov/upload:
           file: .coverage.xml
 
-  test-3_6:
+  test-3_7:
     <<: *test-template
     docker:
       - image: circleci/python:3.6.8
-  # test-3_8:
-  #   <<: *test-template
-  #   docker:
-  #     - image: circleci/python:3.8.0
+  test-3_7:
+    <<: *test-template
+    docker:
+      - image: circleci/python:3.7.8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
       - codecov/upload:
           file: .coverage.xml
 
-  test-3_7:
+  test-3_6:
     <<: *test-template
     docker:
       - image: circleci/python:3.6.8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,18 @@ workflows:
       - test-3_8
       - test-3_7
       - test-3_6
+  weekly:
+    triggers:
+      - schedule:
+        cron: "0 0 * * 6"
+        filters:
+          branches:
+            only:
+              - master
+    jobs:
+      - test-3_8
+      - test-3_7
+      - test-3_6
 
 jobs:
   test-3_8: &test-template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,11 +17,11 @@ workflows:
   weekly:
     triggers:
       - schedule:
-        cron: "0 0 * * 6"
-        filters:
-          branches:
-            only:
-              - master
+          cron: "0 0 * * 6"
+          filters:
+            branches:
+              only:
+                - master
     jobs:
       - test-3_8
       - test-3_7


### PR DESCRIPTION
Adding Python 3.8 to the test regime is useful, and scheduling a weekly test means we won't let third-party/other changes cryptically bork things if it's a long time between pushes.