### PR TITLE
Fix anim recovery mode

### DIFF
--- a/pyani/anim.py
+++ b/pyani/anim.py
@@ -205,7 +205,8 @@ def construct_nucmer_cmdline(
     fname1, fname2 = Path(fname1), Path(fname2)
 
     # Compile commands
-    outsubdir = outdir / pyani_config.ALIGNDIR["ANIm"]
+    outsubdir = outdir / pyani_config.ALIGNDIR["ANIm"] / fname1.stem
+    outsubdir.mkdir(exist_ok=True)
     outprefix = outsubdir / f"{fname1.stem}_vs_{fname2.stem}"
     if maxmatch:
         mode = "--maxmatch"
@@ -318,7 +319,15 @@ def process_deltadir(
     """
     # Process directory to identify input files - as of v0.2.4 we use the
     # .filter files that result from delta-filter (1:1 alignments)
-    deltafiles = pyani_files.get_input_files(delta_dir, ".filter")
+    deltafiles = sorted(delta_dir.glob("*/*.filter"))
+    import sys
+
+    sys.exit(f"{delta_dir} has {len(deltafiles)} files to load")
+    if not deltafiles:
+        sys.exit(f"{delta_dir} empty? No filter files found")
+    if not logger:
+        logger = logging.getLogger(__name__)
+    logger.debug(f"Found {len(deltafiles)} filter files in {delta_dir}")
 
     # Hold data in ANIResults object
     results = ANIResults(list(org_lengths.keys()), "ANIm")
@@ -356,6 +365,7 @@ def process_deltadir(
                 logger.warning(
                     "Total alignment length reported in %s is zero!", deltafile
                 )
+            sys.exit("Zero length alignment!")
         query_cover = float(tot_length) / org_lengths[qname]
         sbjct_cover = float(tot_length) / org_lengths[sname]
 

--- a/pyani/pyani_files.py
+++ b/pyani/pyani_files.py
@@ -190,10 +190,9 @@ def collect_existing_output(dirpath: Path, program: str, args: Namespace) -> Lis
     # Obtain collection of expected output files already present in directory
     if program == "nucmer":
         if args.nofilter:
-            suffix = ".delta"
+            pattern = "*/*.delta"
         else:
-            suffix = ".filter"
+            pattern = "*/*.filter"
     elif program == "blastn":
-        suffix = ".blast_tab"
-    existingfiles = [fname for fname in dirpath.iterdir() if fname.suffix == suffix]
-    return existingfiles
+        pattern = "*.blast_tab"
+    return sorted(dirpath.glob(pattern))

--- a/pyani/pyani_orm.py
+++ b/pyani/pyani_orm.py
@@ -515,7 +515,7 @@ def add_run_genomes(
             indesc = read_fasta_description(fastafile)
         except Exception:
             raise PyaniORMException("Could not read genome files for database import")
-        abspath = fastafile.resolve()
+        abspath = fastafile.absolute()
         genome_len = get_genome_length(abspath)
 
         # If the genome is not already in the database, add it as a Genome object

--- a/pyani/scripts/subcommands/subcmd_anib.py
+++ b/pyani/scripts/subcommands/subcmd_anib.py
@@ -218,12 +218,17 @@ def subcmd_anib(args: Namespace) -> None:
             "\tIn this mode, existing comparison output from %s is reused", args.outdir
         )
         existingfiles = collect_existing_output(args.outdir, "blastn", args)
-        logger.debug(
-            "\tIdentified %s existing output files for reuse", len(existingfiles)
-        )
+        if existingfiles:
+            logger.debug(
+                "\tIdentified %s existing output files for reuse, %s (etc)",
+                len(existingfiles),
+                existingfiles[0],
+            )
+        else:
+            logger.debug(f"\tIdentified no existing output files")
     else:
-        existingfiles = None
-        logger.debug(f"\tIdentified no existing output files")
+        existingfiles = list()
+        logger.debug("\tAssuming no pre-existing output files")
 
     # Split the input genome files into contiguous fragments of the specified size,
     # as described in Goris et al. We create a new directory to hold sequence

--- a/pyani/scripts/subcommands/subcmd_anim.py
+++ b/pyani/scripts/subcommands/subcmd_anim.py
@@ -273,12 +273,17 @@ def subcmd_anim(args: Namespace) -> None:
             "\tIn this mode, existing comparison output from %s is reused", deltadir
         )
         existingfiles = collect_existing_output(deltadir, "nucmer", args)
-        logger.debug(
-            "\tIdentified %s existing output files for reuse", len(existingfiles)
-        )
+        if existingfiles:
+            logger.debug(
+                "\tIdentified %s existing output files for reuse: %s (etc)",
+                len(existingfiles),
+                existingfiles[0],
+            )
+        else:
+            logger.debug("\tIdentified no existing output files")
     else:
         existingfiles = list()
-        logger.debug("\tIdentified no existing output files")
+        logger.debug("\tAssuming no pre-existing output files")
 
     # Create list of NUCmer jobs for each comparison still to be performed
     logger.info("Creating NUCmer jobs for ANIm")
@@ -302,7 +307,7 @@ def subcmd_anim(args: Namespace) -> None:
 
 
 def generate_joblist(
-    comparisons: List[Tuple], existingfiles: List[Path], args: Namespace,
+    comparisons: List[Tuple], existingfiles: List[Path], args: Namespace
 ) -> List[ComparisonJob]:
     """Return list of ComparisonJobs.
 
@@ -311,6 +316,8 @@ def generate_joblist(
     :param args:  Namespace of command-line arguments for the run
     """
     logger = logging.getLogger(__name__)
+
+    existingfiles = set(existingfiles)  # Path objects hashable
 
     joblist = []  # will hold ComparisonJob structs
     for idx, (query, subject) in enumerate(
@@ -335,11 +342,11 @@ def generate_joblist(
         # If we're in recovery mode, we don't want to repeat a computational
         # comparison that already exists, so we check whether the ultimate
         # output is in the set of existing files and, if not, we add the jobs
-        # TODO: something faster than a list search (dict or set?)
+
         # The comparisons collections always gets updated, so that results are
         # added to the database whether they come from recovery mode or are run
         # in this call of the script.
-        if args.recovery and outfname.name in existingfiles:
+        if args.recovery and outfname in existingfiles:
             logger.debug("Recovering output from %s, not building job", outfname)
         else:
             logger.debug("Building job")
@@ -359,7 +366,7 @@ def run_anim_jobs(joblist: List[ComparisonJob], args: Namespace) -> None:
     """
     logger = logging.getLogger(__name__)
     logger.debug("Scheduler: %s", args.scheduler)
-    
+
     if args.scheduler == "multiprocessing":
         logger.info("Running jobs with multiprocessing")
         if not args.workers:
@@ -391,7 +398,7 @@ def run_anim_jobs(joblist: List[ComparisonJob], args: Namespace) -> None:
 
 
 def update_comparison_results(
-    joblist: List[ComparisonJob], run, session, nucmer_version: str, args: Namespace,
+    joblist: List[ComparisonJob], run, session, nucmer_version: str, args: Namespace
 ) -> None:
     """Update the Comparison table with the completed result set.
 

--- a/pyani/scripts/subcommands/subcmd_anim.py
+++ b/pyani/scripts/subcommands/subcmd_anim.py
@@ -274,13 +274,13 @@ def subcmd_anim(args: Namespace) -> None:
         )
         existingfiles = collect_existing_output(deltadir, "nucmer", args)
         if existingfiles:
-            logger.debug(
-                "\tIdentified %s existing output files for reuse: %s (etc)",
+            logger.info(
+                "Recover mode identified %s existing output files for reuse: %s (etc)",
                 len(existingfiles),
                 existingfiles[0],
             )
         else:
-            logger.debug("\tIdentified no existing output files")
+            logger.info("Recovery mode identified no existing output files")
     else:
         existingfiles = list()
         logger.debug("\tAssuming no pre-existing output files")
@@ -347,7 +347,9 @@ def generate_joblist(
         # added to the database whether they come from recovery mode or are run
         # in this call of the script.
         if args.recovery and outfname in existingfiles:
-            logger.debug("Recovering output from %s, not building job", outfname)
+            logger.debug("Recovering output from %s, not submitting job", outfname)
+            # Need to track the expected output, but set the job itself to None:
+            joblist.append(ComparisonJob(query, subject, dcmd, ncmd, outfname, None))
         else:
             logger.debug("Building job")
             # Build jobs
@@ -367,15 +369,16 @@ def run_anim_jobs(joblist: List[ComparisonJob], args: Namespace) -> None:
     logger = logging.getLogger(__name__)
     logger.debug("Scheduler: %s", args.scheduler)
 
+    # Entries with None seen in recovery mode:
+    jobs = [_.job for _ in joblist if _.job]
+
     if args.scheduler == "multiprocessing":
         logger.info("Running jobs with multiprocessing")
         if not args.workers:
             logger.debug("(using maximum number of worker threads)")
         else:
             logger.debug("(using %d worker threads, if available)", args.workers)
-        cumval = run_mp.run_dependency_graph(
-            [_.job for _ in joblist], workers=args.workers
-        )
+        cumval = run_mp.run_dependency_graph(jobs, workers=args.workers)
         if cumval > 0:
             logger.error(
                 "At least one NUCmer comparison failed. Please investigate (exiting)"
@@ -387,7 +390,7 @@ def run_anim_jobs(joblist: List[ComparisonJob], args: Namespace) -> None:
         logger.debug("Setting jobarray group size to %d", args.sgegroupsize)
         logger.debug("Joblist contains %d jobs", len(joblist))
         run_sge.run_dependency_graph(
-            [_.job for _ in joblist],
+            jobs,
             jgprefix=args.jobprefix,
             sgegroupsize=args.sgegroupsize,
             sgeargs=args.sgeargs,

--- a/pyani/scripts/subcommands/subcmd_plot.py
+++ b/pyani/scripts/subcommands/subcmd_plot.py
@@ -114,6 +114,7 @@ def write_run_heatmaps(
     )
     result_label_dict = pyani_orm.get_matrix_labels_for_run(session, args.run_id)
     result_class_dict = pyani_orm.get_matrix_classes_for_run(session, args.run_id)
+    logger.debug(f"Have {len(result_label_dict)} labels and {len(result_class_dict)} classes")
 
     # Write heatmap for each results matrix
     for matdata in [


### PR DESCRIPTION
I found anim was not reusing pre-existing files.

My fix was using Path object directly, not just the filename (which discards the path information). Could alternatively have built or converted the expected list into filenames only?

Also turns the list of Path objects into a set for a slight speed up (addresses a TODO comment), and adds a bit more debugging.

As far as I can see, anib does not support recovery mode (untested)?