### PR TITLE
add sqlalchemy to setup.py - fix #244

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ setuptools.setup(
         "pandas",
         "scipy",
         "seaborn",
+        "sqlalchemy",
         "tqdm",
     ],
     classifiers=[


### PR DESCRIPTION
This should fix #244, which was preventing correct installation using
`python setup.py install` and `pip install -e .`