### PR TITLE
Add `--version` and  `--citation` flags

### DIFF
--- a/pyani/scripts/parsers/__init__.py
+++ b/pyani/scripts/parsers/__init__.py
@@ -98,11 +98,7 @@ def parse_cmdline(argv: Optional[List] = None) -> Namespace:
         "--version", action="version", version="%(prog)s 0.3.0-alpha"
     )
     parser_main.add_argument(
-        "--citation",
-        action="store_true",
-        dest="citation",
-        default=False,
-        help="Display pyani citation",
+        "--citation", action="store_true", dest="citation", default=False, help="Display pyani citation"
     )
 
     # Parsers common to multiple subcommand parsers

--- a/pyani/scripts/parsers/__init__.py
+++ b/pyani/scripts/parsers/__init__.py
@@ -94,6 +94,16 @@ def parse_cmdline(argv: Optional[List] = None) -> Namespace:
     subparsers = parser_main.add_subparsers(
         title="subcommands", description="valid subcommands", help="additional help"
     )
+        parser_main.add_argument(
+        "--version", action="version", version="%(prog)s 0.3.0-alpha"
+    )
+    parser_main.add_argument(
+        "--citation",
+        action="store_true",
+        dest="citation",
+        default=False,
+        help="Display pyani citation",
+    )
 
     # Parsers common to multiple subcommand parsers
     parser_common = common_parser.build()

--- a/pyani/scripts/parsers/__init__.py
+++ b/pyani/scripts/parsers/__init__.py
@@ -94,11 +94,17 @@ def parse_cmdline(argv: Optional[List] = None) -> Namespace:
     subparsers = parser_main.add_subparsers(
         title="subcommands", description="valid subcommands", help="additional help"
     )
-        parser_main.add_argument(
-        "--version", action="version", version="%(prog)s 0.3.0-alpha"
+    parser_main.add_argument(
+        "--version", 
+        action="version", 
+        version="%(prog)s 0.3.0-alpha"
     )
     parser_main.add_argument(
-        "--citation", action="store_true", dest="citation", default=False, help="Display pyani citation"
+        "--citation", 
+        action="store_true", 
+        dest="citation", 
+        default=False, 
+        help="Display pyani citation"
     )
 
     # Parsers common to multiple subcommand parsers

--- a/pyani/scripts/parsers/anib_parser.py
+++ b/pyani/scripts/parsers/anib_parser.py
@@ -64,16 +64,6 @@ def build(
     parser = subps.add_parser(
         "anib", parents=parents, formatter_class=ArgumentDefaultsHelpFormatter
     )
-    # Required positional arguments: input and output directories
-    # parser.add_argument(
-    #    "--version",
-    #    action="version",
-    #    version="pyani.py version: {0};   {1} version: {2}".format(
-    #        __version__,
-    #        pyani_config.BLASTN_DEFAULT,
-    #        anib.get_version(pyani_config.BLASTN_DEFAULT).split('_')[-1],
-    #    ),
-    # )
     parser.add_argument(
         "-i",
         action="store",

--- a/pyani/scripts/parsers/anib_parser.py
+++ b/pyani/scripts/parsers/anib_parser.py
@@ -42,8 +42,11 @@ from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, _SubParsersA
 from pathlib import Path
 from typing import List, Optional
 
+from pyani import anib
 from pyani import pyani_config
 from pyani.scripts import subcommands
+
+from pyani import __version__
 
 
 def build(
@@ -62,7 +65,17 @@ def build(
         "anib", parents=parents, formatter_class=ArgumentDefaultsHelpFormatter
     )
     # Required positional arguments: input and output directories
+    # parser.add_argument(
+    #    "--version",
+    #    action="version",
+    #    version="pyani.py version: {0};   {1} version: {2}".format(
+    #        __version__,
+    #        pyani_config.BLASTN_DEFAULT,
+    #        anib.get_version(pyani_config.BLASTN_DEFAULT).split('_')[-1],
+    #    ),
+    # )
     parser.add_argument(
+        "-i",
         action="store",
         dest="indir",
         default=None,
@@ -70,6 +83,7 @@ def build(
         help="input genome directory",
     )
     parser.add_argument(
+        "-o",
         action="store",
         dest="outdir",
         default=None,

--- a/pyani/scripts/parsers/anim_parser.py
+++ b/pyani/scripts/parsers/anim_parser.py
@@ -63,6 +63,8 @@ def build(
     )
     # Required positional arguments: input and output directories
     parser.add_argument(
+        "-i",
+        "--indir",
         action="store",
         dest="indir",
         default=None,
@@ -70,6 +72,8 @@ def build(
         help="input genome directory",
     )
     parser.add_argument(
+        "-o",
+        "--outdir",
         action="store",
         dest="outdir",
         default=None,
@@ -77,15 +81,15 @@ def build(
         help="output analysis results directory",
     )
     # Optional arguments
-    parser.add_argument(
-        "--version",
-        action="version",
-        version="pyani.py version: {0}; {1} version: {2}".format(
-            __version__,
-            pyani_config.NUCMER_DEFAULT,
-            anim.get_version(pyani_config.NUCMER_DEFAULT).split("_")[-1],
-        ),
-    )
+    # parser.add_argument(
+    #    "--version",
+    #    action="version",
+    #    version="pyani.py version: {0}§ {1} version: {2}".format(
+    #        __version__,
+    #        pyani_config.NUCMER_DEFAULT,
+    #        anim.get_version(pyani_config.NUCMER_DEFAULT).split("_")[-1],
+    #    ).replace('§', '\n\n    '),
+    # )
     parser.add_argument(
         "--dbpath",
         action="store",

--- a/pyani/scripts/parsers/anim_parser.py
+++ b/pyani/scripts/parsers/anim_parser.py
@@ -80,16 +80,6 @@ def build(
         type=Path,
         help="output analysis results directory",
     )
-    # Optional arguments
-    # parser.add_argument(
-    #    "--version",
-    #    action="version",
-    #    version="pyani.py version: {0}§ {1} version: {2}".format(
-    #        __version__,
-    #        pyani_config.NUCMER_DEFAULT,
-    #        anim.get_version(pyani_config.NUCMER_DEFAULT).split("_")[-1],
-    #    ).replace('§', '\n\n    '),
-    # )
     parser.add_argument(
         "--dbpath",
         action="store",

--- a/pyani/scripts/parsers/anim_parser.py
+++ b/pyani/scripts/parsers/anim_parser.py
@@ -37,13 +37,17 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 """Provides parser for anim subcommand."""
+import sys
 
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, _SubParsersAction
 from pathlib import Path
 from typing import List, Optional
 
 from pyani import pyani_config
+from pyani import anim
 from pyani.scripts import subcommands
+
+from pyani import __version__
 
 
 def build(
@@ -73,6 +77,15 @@ def build(
         help="output analysis results directory",
     )
     # Optional arguments
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="pyani.py version: {0}; {1} version: {2}".format(
+            __version__,
+            pyani_config.NUCMER_DEFAULT,
+            anim.get_version(pyani_config.NUCMER_DEFAULT).split("_")[-1],
+        ),
+    )
     parser.add_argument(
         "--dbpath",
         action="store",

--- a/pyani/scripts/parsers/common_parser.py
+++ b/pyani/scripts/parsers/common_parser.py
@@ -37,7 +37,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 """Provides parser for arguments common to all subcommands."""
-
+import sys
 from argparse import ArgumentParser
 
 from pathlib import Path
@@ -56,6 +56,12 @@ def build() -> ArgumentParser:
     -v, --verbose (produce verbose output on STDOUT)
     """
     parser = ArgumentParser(add_help=False)
+    parser.add_argument(
+        "--version",
+        dest="version",
+        action="store_true",
+        default=False,
+    )
     parser.add_argument(
         "-l",
         "--logfile",

--- a/pyani/scripts/pyani_script.py
+++ b/pyani/scripts/pyani_script.py
@@ -45,6 +45,8 @@ import time
 
 from typing import List, Optional
 
+# from . import pyani_config
+
 from pyani.logger import config_logger
 from pyani.pyani_tools import termcolor
 
@@ -58,7 +60,8 @@ CITATION_INFO = [
         "green",
     ),
     termcolor(
-        "\tPritchard, L., Glover, R. H., Humphris, S., Elphinstone, J. G.,", "yellow",
+        "\tPritchard, L., Glover, R. H., Humphris, S., Elphinstone, J. G.,",
+        "yellow",
     ),
     termcolor(
         "\t& Toth, I.K. (2016) 'Genomics and taxonomy in diagnostics for", "yellow"
@@ -94,7 +97,7 @@ def run_main(argv: Optional[List[str]] = None) -> int:
         sys.stderr.write(termcolor("CITATION INFO:\n\n", bold=True))
         for line in CITATION_INFO:
             sys.stderr.write("{0}\n".format(line))
-        return 0    
+        return 0
 
     # Set up logging
     time0 = time.time()

--- a/pyani/scripts/pyani_script.py
+++ b/pyani/scripts/pyani_script.py
@@ -53,6 +53,10 @@ from pyani.pyani_tools import termcolor
 from .parsers import parse_cmdline
 from .. import __version__
 
+from pyani.anib import get_version as get_blast_version
+from pyani.aniblastall import get_version as get_blastall_version
+from pyani.anim import get_version as get_nucmer_version
+
 
 CITATION_INFO = [
     termcolor(
@@ -76,6 +80,25 @@ CITATION_INFO = [
 ]
 
 
+def subcmd_version(subcmd: str) -> str:
+    """Retrieve version information for subcommands
+
+    :param subcmd:  str, name of a subcommand
+
+    Calls the version of get_version() defined for subcmd and returns the version
+    number from that function's output.
+    """
+    return (
+        {
+            "anib": lambda: get_blast_version(),
+            "anim": lambda: get_nucmer_version(),
+            "aniblastall": lambda: get_blastall_version(),
+        }
+        .get(subcmd, lambda: None)()
+        .split("_")[-1]
+    )
+
+
 # Main function
 def run_main(argv: Optional[List[str]] = None) -> int:
     """Run main process for pyani.py script.
@@ -90,13 +113,19 @@ def run_main(argv: Optional[List[str]] = None) -> int:
 
     # Catch execution with no arguments
     if len(sys.argv) == 1:
-        sys.stderr.write("pyani version: {0}\n".format(__version__))
+        sys.stderr.write(f"pyani {__version__}")
         return 0
     elif len(sys.argv) == 2 and args.citation:
-        sys.stderr.write("pyani version: {0}\n\n".format(__version__))
+        sys.stderr.write("pyani version: {__version__}\n\n")
         sys.stderr.write(termcolor("CITATION INFO:\n\n", bold=True))
         for line in CITATION_INFO:
-            sys.stderr.write("{0}\n".format(line))
+            sys.stderr.write(f"{line}\n")
+        return 0
+    elif args.version:
+        sys.stderr.write(f"pyani {__version__}\n")
+        subcmd = sys.argv[1]
+        v_num = subcmd_version(subcmd)
+        sys.stderr.write(f"{subcmd} {v_num}\n")
         return 0
 
     # Set up logging

--- a/pyani/scripts/pyani_script.py
+++ b/pyani/scripts/pyani_script.py
@@ -89,6 +89,12 @@ def run_main(argv: Optional[List[str]] = None) -> int:
     if len(sys.argv) == 1:
         sys.stderr.write("pyani version: {0}\n".format(__version__))
         return 0
+    elif len(sys.argv) == 2 and args.citation:
+        sys.stderr.write("pyani version: {0}\n\n".format(__version__))
+        sys.stderr.write(termcolor("CITATION INFO:\n\n", bold=True))
+        for line in CITATION_INFO:
+            sys.stderr.write("{0}\n".format(line))
+        return 0    
 
     # Set up logging
     time0 = time.time()


### PR DESCRIPTION
This adds the new flags to `-h` output, and makes them valid options to `pyani`. The current handling for `--citation` outputs `CITATION_INFO` if it is passed as the only argument. Otherwise, (I think) there will always be at least one subparser involved, so then it will exhibit its previous behaviour.

Closes #262 