### PR TITLE
fix #287 - allows empty sys.argv if arguments passed

### DIFF
--- a/pyani/scripts/pyani_script.py
+++ b/pyani/scripts/pyani_script.py
@@ -58,8 +58,7 @@ CITATION_INFO = [
         "green",
     ),
     termcolor(
-        "\tPritchard, L., Glover, R. H., Humphris, S., Elphinstone, J. G.,",
-        "yellow",
+        "\tPritchard, L., Glover, R. H., Humphris, S., Elphinstone, J. G.,", "yellow",
     ),
     termcolor(
         "\t& Toth, I.K. (2016) 'Genomics and taxonomy in diagnostics for", "yellow"
@@ -87,7 +86,7 @@ def run_main(argv: Optional[List[str]] = None) -> int:
         args = parse_cmdline(argv)
 
     # Catch execution with no arguments
-    if len(sys.argv) == 1:
+    if len(sys.argv) == 1 and argv is None:
         sys.stderr.write("pyani version: {0}\n".format(__version__))
         return 0
 


### PR DESCRIPTION
The `pyani_script.run_main()` function had a logic error where in all cases that `sys.argv` contained only the empty string, the `pyani` version info would be returned. As calls to `run_main()` passing arguments did not update `sys.argv` all calls to `run_main()` from test code or when profiling would return the `pyani` version and exit, rather than running the application.

This fix checks to see if, when `sys.argv` is "empty", some arguments may have been passed in the function call. If so, the `pyani` version statement is not shown, and the code runs.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [x] Fork the `pyani` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [X] Set up an appropriate development environment (please see `CONTRIBUTING.md`)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed
  - [x] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [ ] Test locally with `pytest -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with `flake8` and `black` before submission
- [X] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [ ] Request a code review
- [ ] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani/pulls) in the `pyani` repository
