### PR TITLE
Test for `create_hash` when the 'file' given does not exist

### DIFF
--- a/tests/test_subcmd_01_download.py
+++ b/tests/test_subcmd_01_download.py
@@ -117,6 +117,7 @@ assertions = TestCase("__init__")
 
 
 def test_create_hash():
+    """Test that the expected exception is raised if the file doesn't exist."""
     test_file = "/this/is/not/a/file"
     with assertions.assertRaises(download.PyaniIndexException):
         download.create_hash(test_file)

--- a/tests/test_subcmd_01_download.py
+++ b/tests/test_subcmd_01_download.py
@@ -66,6 +66,7 @@ from unittest.mock import patch
 
 import pytest
 
+from pyani import download
 from pyani.scripts import subcommands
 from tools import modify_namespace
 
@@ -109,6 +110,16 @@ def kraken_namespace(base_download_namespace, tmp_path):
     return modify_namespace(
         base_download_namespace, kraken=True, outdir=tmp_path / "kraken"
     )
+
+
+# Create object for accessing unittest assertions
+assertions = TestCase("__init__")
+
+
+def test_create_hash():
+    test_file = "/this/is/not/a/file"
+    with assertions.assertRaises(download.PyaniIndexException):
+        download.create_hash(test_file)
 
 
 def test_download_dry_run(dryrun_namespace):


### PR DESCRIPTION
Added a test for coverage.


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md`)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed
  - [x] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [x] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with `flake8` and `black` before submission
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [ ] Request a code review
- [ ] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani/pulls) in the `pyani` repository
