### PR TITLE
Mention `pip install -e .` in install instructions for developers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,13 +103,13 @@ If you want to be able to edit source files and have those changes take immediat
 git clone https://github.com/widdowquinn/pyani.git
 ```
 
-, then inside the new `pyani` directory run:
+then inside the new `pyani` directory run:
 
 ```bash
 pip install -e .
 ```
 
-This will add `pyani` to your path, and allow you to test changes as you make them.
+This is the [`pip install --editable`](https://pip.pypa.io/en/stable/cli/pip_install/#install-editable) command, which links the installed package to the specified location (here `.`, i.e. the current directory) rather than the usual package location (`site-packages`). When using this option, edits to the source code are immediately available in the installed package. This allows you to test changes to the source code as you make them, without the need for an additional uninstall/install step.
 
 #### Cleaning up development environment
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,20 @@ This will install all dependencies for running and developing `pyani`, as well a
 make test
 ```
 
+If you want to be able to edit source files and have those changes take immediate effect when calling `pyani` (useful for testing), clone the GitHub repository with:
+
+```bash
+git clone https://github.com/widdowquinn/pyani.git
+```
+
+, then inside the new `pyani` directory run:
+
+```bash
+pip install -e .
+```
+
+This will add `pyani` to your path, and allow you to test changes as you make them.
+
 #### Cleaning up development environment
 
 You can remove the `conda` development environment with the following commands:
@@ -219,7 +233,7 @@ A good long description could be
 > This fix improves efficiency of the veeblefetzer. The main change is replacing a
 > nested loop with asyncio calls to a new function `fetzveebles()`. This commit
 > makes affects `veebles.py`, and new tests are added in `test_veeblefetzer.py`.
-> 
+>
 > fixes #246
 
 A bad long description might be

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -82,6 +82,7 @@ Making changes and pull requests
 
 1. Fork the ``pyani`` `repository`_ under your account at `GitHub`_.
 2. Clone your fork to your development machine.
+2a. To be able to run `pyani` and have changes you make take effect (useful for testing), you can run `pip install -e .` inside the local cloned repository. 
 3. Create a new branch in your forked repository with an informative name like ``fix_issue_107``, using ``git`` (e.g. with the command ``git checkout -b fix_issue_107``).
 4. Make the changes you need and commit them to your local branch.
 5. Run the repository tests (see the :ref:`pyani-testing` documentation for more details).

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -82,7 +82,7 @@ Making changes and pull requests
 
 1. Fork the ``pyani`` `repository`_ under your account at `GitHub`_.
 2. Clone your fork to your development machine.
-2a. To be able to run `pyani` and have changes you make take effect (useful for testing), you can run `pip install -e .` inside the local cloned repository. 
+  - To be able to edit `pyani` and have changes you make take effect immediately without a reinstall (useful for testing), you can run `pip install -e .` inside the local cloned repository. 
 3. Create a new branch in your forked repository with an informative name like ``fix_issue_107``, using ``git`` (e.g. with the command ``git checkout -b fix_issue_107``).
 4. Make the changes you need and commit them to your local branch.
 5. Run the repository tests (see the :ref:`pyani-testing` documentation for more details).


### PR DESCRIPTION
Mention this very useful line of code that developers might like to know about.

I think the wording probably needs to be different, particularly in `CONTRIBUTING.md`—I think this is still not completely clear on the distinction between setting up an environment versus a local repo that can be actively modified, but talking it through might help.

Closes #316.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [x] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md`)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed
  - [ ] new code is commented, especially in hard-to-understand areas
  - [x] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [ ] Test locally with `pytest -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with `flake8` and `black` before submission
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [ ] Request a code review
- [ ] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani/pulls) in the `pyani` repository
