### PR TITLE
Sort genomes (for stable anim recovery mode)

### DIFF
--- a/pyani/anim.py
+++ b/pyani/anim.py
@@ -233,7 +233,7 @@ def construct_nucmer_cmdline(
     outdir, called "nucmer_output".
     """
     # Cast path strings to pathlib.Path for safety
-    fname1, fname2 = Path(fname1), Path(fname2)
+    fname1, fname2 = sorted([Path(fname1), Path(fname2)])
 
     # Compile commands
     # Nested output folders to avoid N^2 scaling in files-per-folder

--- a/pyani/pyani_files.py
+++ b/pyani/pyani_files.py
@@ -74,15 +74,15 @@ def get_fasta_paths(
     :param dirname:  Path, path to directory containing input FASTA files
     :param extlist:  List, file suffixes for FASTA files
 
-    Returns the full path to each file.
+    Returns sorted list of the full path to each file.
     """
     # Lists are dangerous to have as default function arguments
     extlist = extlist or [".fna", ".fa", ".fasta", ".fas"]
-    return [
+    return sorted(
         fname
         for fname in dirname.iterdir()
         if fname.is_file() and fname.suffix in extlist
-    ]
+    )
 
 
 # Get a list of FASTA files and corresponding hashes from the input directory
@@ -116,12 +116,12 @@ def get_fasta_and_hash_paths(dirname: Path = Path(".")) -> List[Tuple[Path, Path
 
 # Get list of FASTA files in a directory
 def get_input_files(dirname: Path, *ext) -> List[Path]:
-    """Return files in passed directory, filtered by extension.
+    """Return sorted files in passed directory, filtered by extension.
 
     :param dirname:  Path, path to input directory
     :param *ext:  optional iterable of arguments describing permitted file extensions
     """
-    return [fname for fname in dirname.iterdir() if fname.suffix in ext]
+    return sorted(fname for fname in dirname.iterdir() if fname.suffix in ext)
 
 
 # Get lengths of input sequences

--- a/pyani/scripts/subcommands/subcmd_anim.py
+++ b/pyani/scripts/subcommands/subcmd_anim.py
@@ -324,6 +324,8 @@ def generate_joblist(
     for idx, (query, subject) in enumerate(
         tqdm(comparisons, disable=args.disable_tqdm)
     ):
+        if subject.path < query.path:
+            query, subject = subject, query  # sort them
         ncmd, dcmd = anim.construct_nucmer_cmdline(
             query.path,
             subject.path,

--- a/pyani/scripts/subcommands/subcmd_anim.py
+++ b/pyani/scripts/subcommands/subcmd_anim.py
@@ -324,8 +324,6 @@ def generate_joblist(
     for idx, (query, subject) in enumerate(
         tqdm(comparisons, disable=args.disable_tqdm)
     ):
-        if subject.path < query.path:
-            query, subject = subject, query  # sort them
         ncmd, dcmd = anim.construct_nucmer_cmdline(
             query.path,
             subject.path,

--- a/pyani/scripts/subcommands/subcmd_anim.py
+++ b/pyani/scripts/subcommands/subcmd_anim.py
@@ -351,7 +351,7 @@ def generate_joblist(
             logger.debug("Recovering output from %s, not submitting job", outfname)
             # Need to track the expected output, but set the job itself to None:
             joblist.append(ComparisonJob(query, subject, dcmd, ncmd, outfname, None))
-            jobs["new"] += 1
+            jobs["old"] += 1
         else:
             logger.debug("Building job")
             # Build jobs
@@ -359,10 +359,12 @@ def generate_joblist(
             fjob = pyani_jobs.Job("%s_%06d-f" % (args.jobprefix, idx), dcmd)
             fjob.add_dependency(njob)
             joblist.append(ComparisonJob(query, subject, dcmd, ncmd, outfname, fjob))
-            jobs["old"] += 1
-    logger.info(f"New comparisons to run: {jobs['new']}.")
-    if jobs["old"]:
-        logger.info(f"\nRetrieving output from {jobs['old']} previous comparisons.")
+            jobs["new"] += 1
+    logger.info(
+        f"No results found for {jobs['new']} comparisons; {jobs['new']} new jobs built."
+    )
+    if existingfiles:
+        logger.info(f"Retrieving results for {jobs['old']} previous comparisons.")
     return joblist
 
 

--- a/pyani/scripts/subcommands/subcmd_anim.py
+++ b/pyani/scripts/subcommands/subcmd_anim.py
@@ -361,10 +361,12 @@ def generate_joblist(
             joblist.append(ComparisonJob(query, subject, dcmd, ncmd, outfname, fjob))
             jobs["new"] += 1
     logger.info(
-        f"No results found for {jobs['new']} comparisons; {jobs['new']} new jobs built."
+        "Results not found for %d comparisons; %d new jobs built.",
+        jobs["new"],
+        jobs["new"],
     )
     if existingfiles:
-        logger.info(f"Retrieving results for {jobs['old']} previous comparisons.")
+        logger.info("Retrieving results for %d previous comparisons.", jobs["old"])
     return joblist
 
 

--- a/pyani/scripts/subcommands/subcmd_anim.py
+++ b/pyani/scripts/subcommands/subcmd_anim.py
@@ -320,6 +320,7 @@ def generate_joblist(
     existingfiles = set(existingfiles)  # Path objects hashable
 
     joblist = []  # will hold ComparisonJob structs
+    jobs = {"new": 0, "old": 0}  # will hold counts of new/old jobs for reporting
     for idx, (query, subject) in enumerate(
         tqdm(comparisons, disable=args.disable_tqdm)
     ):
@@ -350,6 +351,7 @@ def generate_joblist(
             logger.debug("Recovering output from %s, not submitting job", outfname)
             # Need to track the expected output, but set the job itself to None:
             joblist.append(ComparisonJob(query, subject, dcmd, ncmd, outfname, None))
+            jobs["new"] += 1
         else:
             logger.debug("Building job")
             # Build jobs
@@ -357,6 +359,10 @@ def generate_joblist(
             fjob = pyani_jobs.Job("%s_%06d-f" % (args.jobprefix, idx), dcmd)
             fjob.add_dependency(njob)
             joblist.append(ComparisonJob(query, subject, dcmd, ncmd, outfname, fjob))
+            jobs["old"] += 1
+    logger.info(f"New comparisons to run: {jobs['new']}.")
+    if jobs["old"]:
+        logger.info(f"\nRetrieving output from {jobs['old']} previous comparisons.")
     return joblist
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,12 @@ FIXTUREPATH = TESTSPATH / "fixtures"
 
 
 # Convenience structs to emulate returned objects
+class MockGenome(NamedTuple):
+    """Mock genome object."""
+
+    path: str
+
+
 class MockProcess(NamedTuple):
     """Mock process object."""
 
@@ -265,6 +271,13 @@ def executable_without_version(monkeypatch):
 def fragment_length():
     """Fragment size for ANIb-related analyses."""
     return FRAGSIZE
+
+
+@pytest.fixture
+def unsorted_genomes(dir_anim_in):
+    """Tests ordering of genome names in output file names for asymmetric analyses."""
+    dir_anim_in = str(dir_anim_in)
+    return (MockGenome(f"{dir_anim_in}/second"), MockGenome(f"{dir_anim_in}/first"))
 
 
 @pytest.fixture

--- a/tests/test_anim.py
+++ b/tests/test_anim.py
@@ -250,3 +250,14 @@ def test_mummer_job_generation(mummer_cmds_four):
         assert job.name == "test_%06d-f" % idx  # filter job name
         assert len(job.dependencies) == 1  # has NUCmer job
         assert job.dependencies[0].name == "test_%06d-n" % idx
+
+
+def test_genome_sorting(tmp_path, unsorted_genomes):
+    second, first = [Path(_.path) for _ in unsorted_genomes]
+    outprefix = f"{tmp_path}/nucmer_output/{first.stem}/{first.stem}_vs_{second.stem}"
+    expected = (
+        f"nucmer --mum -p {outprefix} {first} {second}",
+        f"delta_filter_wrapper.py delta-filter -1 {outprefix}.delta {outprefix}.filter",
+    )
+    nucmercmd, filtercmd = anim.construct_nucmer_cmdline(second, first, tmp_path)
+    assert (nucmercmd, filtercmd) == expected


### PR DESCRIPTION
This explicitly sorts the FASTA file lists to ensure the genome list is sorted prior to building an all-vs-all matrix. This is important for symmetric methods like anim so that we consistently run ``A_vs_B`` rather than ``B_vs_A`` and thus recovery mode will work stably regardless of the genome order on disk (e.g. cached files have been moved/copied).

Resolves #353 (where examples of both ``A_vs_B`` and ``B_vs_A`` were found on disk).

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [X] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [X] Fork the `pyani` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [X] Set up an appropriate development environment (please see `CONTRIBUTING.md`)
- [X] Create a new branch with a short, descriptive name
- [X] Work on this branch
  - [X] style guidelines have been followed
  - [X] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest -v` **non-passing code will not be merged**
- [X] Rebase against `origin/master`
- [X] Check changes with `flake8` and `black` before submission
- [X] Commit branch
- [X] Submit pull request, describing the content and intent of the pull request
- [ ] Request a code review
- [ ] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani/pulls) in the `pyani` repository
