### PR TITLE
Clarify command line help for report --run_results & --run_matrices

### DIFF
--- a/pyani/scripts/parsers/report_parser.py
+++ b/pyani/scripts/parsers/report_parser.py
@@ -108,7 +108,7 @@ def build(
         "--run_results",
         action="store",
         dest="run_results",
-        metavar="RUN_ID",
+        metavar="RUN_IDS",
         default=False,
         help="Report table of results for comma separated list of runs",
     )
@@ -116,7 +116,7 @@ def build(
         "--run_matrices",
         action="store",
         dest="run_matrices",
-        metavar="RUN_ID",
+        metavar="RUN_IDS",
         default=False,
         help="Report matrices of results for comma separated list of runs",
     )

--- a/pyani/scripts/parsers/report_parser.py
+++ b/pyani/scripts/parsers/report_parser.py
@@ -95,29 +95,30 @@ def build(
         action="store_true",
         dest="show_runs_genomes",
         default=False,
-        help="Report table of all genomes for each run in " + "database",
+        help="Report table of all genomes for each run in database",
     )
     parser.add_argument(
         "--genomes_runs",
         action="store_true",
         dest="show_genomes_runs",
         default=False,
-        help="Report table of all runs in which each genome "
-        + "in the database participates",
+        help="Report table of all runs in which each genome in the database participates",
     )
     parser.add_argument(
         "--run_results",
         action="store",
         dest="run_results",
+        metavar="RUN_ID",
         default=False,
-        help="Report table of results for a pyani run",
+        help="Report table of results for comma separated list of runs",
     )
     parser.add_argument(
         "--run_matrices",
         action="store",
         dest="run_matrices",
+        metavar="RUN_ID",
         default=False,
-        help="Report matrices of results for a pyani run",
+        help="Report matrices of results for comma separated list of runs",
     )
     parser.add_argument(
         "--formats",

--- a/pyani/scripts/parsers/report_parser.py
+++ b/pyani/scripts/parsers/report_parser.py
@@ -109,7 +109,7 @@ def build(
         action="store",
         dest="run_results",
         metavar="RUN_IDS",
-        default=False,
+        default=None,
         help="Report table of results for comma separated list of runs",
     )
     parser.add_argument(
@@ -117,7 +117,7 @@ def build(
         action="store",
         dest="run_matrices",
         metavar="RUN_IDS",
-        default=False,
+        default=None,
         help="Report matrices of results for comma separated list of runs",
     )
     parser.add_argument(


### PR DESCRIPTION
This PR tries to improve the command line help text for ``pyani report`` options ``--run_results`` & ``--run_matrices``. Before:

```
$ pyani report --help
...
  --run_results RUN_RESULTS
                        Report table of results for a pyani run (default:
                        False)
  --run_matrices RUN_MATRICES
                        Report matrices of results for a pyani run (default:
                        False)
...
```

After:

```
$ pyani report --help
...
  --run_results RUN_ID  Report table of results for comma separated list of
                        runs (default: False)
  --run_matrices RUN_ID
                        Report matrices of results for comma separated list of
                        runs (default: False)
...
```

This documents that these arguments can be comma separated lists.

The choice of metavariable name is to match ``pyani plot``:

```
$ pyani plot --help
...
  --run_id RUN_ID       run ID to plot (default: None)
...
```

Perhaps the defaults could be consistent - None in both cases?

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [X] This is a documentation update

## Action Checklist

- [X] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [X] Fork the `pyani` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [X] Set up an appropriate development environment (please see `CONTRIBUTING.md`)
- [X] Create a new branch with a short, descriptive name
- [X] Work on this branch
  - [X] style guidelines have been followed
  - [ ] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [X] Test locally with `pytest -v` **non-passing code will not be merged**
- [X] Rebase against `origin/master`
- [X] Check changes with `flake8` and `black` before submission
- [X] Commit branch
- [X] Submit pull request, describing the content and intent of the pull request
- [ ] Request a code review
- [ ] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani/pulls) in the `pyani` repository
