### PR TITLE
Fix genome labels in matrix output

### DIFF
--- a/pyani/pyani_tools.py
+++ b/pyani/pyani_tools.py
@@ -303,8 +303,9 @@ def label_results_matrix(matrix: pd.DataFrame, labels: Dict) -> pd.DataFrame:
     Applies the labels from the dictionary to the dataframe in
     matrix, and returns the result.
     """
-    matrix.columns = [f"{labels.get(_, _)}:{_}" for _ in matrix.columns]
-    matrix.index = [f"{labels.get(_, _)}:{_}" for _ in matrix.index]
+    # The dictionary uses string keys!
+    matrix.columns = [f"{labels.get(str(_), _)}:{_}" for _ in matrix.columns]
+    matrix.index = [f"{labels.get(str(_), _)}:{_}" for _ in matrix.index]
     return matrix
 
 


### PR DESCRIPTION
Closed #357 - matrix output is not applying labels, e.g. example with 17 genomes:

```
$ head -n 1 matrix_identity_1.tab 
1:1	2:2	3:3	4:4	5:5	6:6	7:7	8:8	9:9	10:10	11:11	12:12	13:13	14:14	15:15	16:16	17:17
```

The problem is a string vs integer mapping, cross reference b54106f36428f017a2589b05de33c0a6d3ed9ea4 (15 Oct 2019) addressing a similar issue with Seaborn plotting.

Where might a test be best added?

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [X] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [X] Fork the `pyani` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [X] Set up an appropriate development environment (please see `CONTRIBUTING.md`)
- [X] Create a new branch with a short, descriptive name
- [X] Work on this branch
  - [X] style guidelines have been followed
  - [X] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [X] Test locally with `pytest -v` **non-passing code will not be merged**
- [X] Rebase against `origin/master`
- [X] Check changes with `flake8` and `black` before submission
- [X] Commit branch
- [X] Submit pull request, describing the content and intent of the pull request
- [ ] Request a code review
- [ ] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani/pulls) in the `pyani` repository
