### PR TITLE
Relocate info about `fastANI` + Python ≥3.9 + macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ DOI: [10.1039/C5AY02550H](https://doi.org/10.1039/C5AY02550H)
     - [`pip`](#pip)
     - [Third-party tools](#third-party-tools)
     - [NOTE: Installing legacy BLAST](#note-installing-legacy-blast)
+    - [Note: Installing fastANi](#note-installing-fastani)
   - [Documentation (v0.3)](#documentation-v03)
     - [Older documentation (v0.2)](#older-documentation-v02)
   - [Bugs, issues, problems and questions](#bugs-issues-problems-and-questions)
@@ -196,42 +197,9 @@ If you wish to use `pyani blastall` or the `ANIblastall` method with the legacy 
 
 **`fastANI` installation (via `conda`) will fail for Python 3.9 on macOS.**
 
-If you are using Python ≥3.9 to run `pyani` on macOS, `fastANI` will fail to install due to errors in the `conda` recipe (for build `h0a26cfa_0`). Using an earlier version of Python may be the simplest solution. However, you can also install `fastANI` yourself—via `conda`—using a slightly altered version of the command produced from the `conda` recipe, as shown below.
+If you are using Python ≥3.9 to run `pyani` on macOS, `fastANI` will fail to install due to errors in the `conda` recipe (for build `h0a26cfa_0`). 
 
-*N.B. We have placed the `fastANI` requirement in its own `requirements-fastani.txt` file so that this will not also cause other installations to fail.*
-
-##### Bypassing `conda`
-
-```bash
-c++ -O3 -DNDEBUG -std=c++11 -Isrc \
--I ${ENV_DIR}/lib/include -mmacosx-version-min=10.7 \
--stdlib=libc++ -Xpreprocessor -fopenmp -lomp \
--DUSE_BOOST src/cgi/core_genome_identity.cpp -o fastANI \
-${ENV_DIR}/lib/lib/libboost_math_c99.a \
--lstdc++ -lz -lm
-```
-
-Two alterations need to be made to the file name specified in the fifth line here:
-
-1. One of the `/lib`s should be removed.
-1. The file extension should be changed from `.a`, to `.dylib`.
-
-The resultant command ought to look something like this (with ${ENV_DIR} being wherever you're installing `fastANI`):
-
-```bash
-c++ -O3 -DNDEBUG -std=c++11 -Isrc \
--I ${ENV_DIR}/lib/include -mmacosx-version-min=10.7 \
--stdlib=libc++ -Xpreprocessor -fopenmp -lomp \
--DUSE_BOOST src/cgi/core_genome_identity.cpp -o fastANI \
-${ENV_DIR}/lib/libboost_math_c99.dylib \
--lstdc++ -lz -lm
-```
-
-For a more technical overview of the issue, and other solutions that may be shared there, please see https://github.com/widdowquinn/pyani/issues/377.
-
-##### Troubleshooting
-
-This solution is how one of our developers managed to solve the problem. We hope it works for you, but can not guarantee this. Unfortunately, if this does not work for you, we will also not be able to troubleshoot the issue. In this instance, please file an issue at https://github.com/bioconda/bioconda-recipes.
+If you encounter this problem, please see the [this section of the wiki]https://github.com/widdowquinn/pyani/wiki/Known-issues-with-third-party-tools#fastani-installation-via-conda-will-fail-for-python-39-on-macos) for help resolving it.
 
 -----
 
@@ -519,7 +487,7 @@ With large datasets, `--method mpl` (matplotlib) is recommended.
 
 Please be aware that the matrix orientation differs for these two options; so, with `seaborn` (the default, `--method seaborn`), the orientation of self-comparisons is top left to bottom right (`\`), while with `matplotlib` (`--method mpl`) the orientation is bottom left to top right (`/`).
 
-### 6. Classifying Genomes from Analysis Results
+<!-- ### 6. Classifying Genomes from Analysis Results -->
 
 -----
 


### PR DESCRIPTION
Move information about problem with `fastANI` + Python ≥3.9 + macOS to wiki (and point people seeing this problem there).

Related to Issue #392, but does not close it (so I haven't linked it).

Please include a summary of the change and which issue is fixed. Please also include the motivation and context, and note the tests that apply to these changes.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [x] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md`)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed
  - [ ] new code is commented, especially in hard-to-understand areas
  - [x] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [ ] Test locally with `pytest -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [ ] Check changes with `flake8` and `black` before submission
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [ ] Request a code review
- [ ] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani/pulls) in the `pyani` repository
