### PR TITLE
Issue# 405: New test case for previously missed code in fastani

### DIFF
--- a/pyani/fastani.py
+++ b/pyani/fastani.py
@@ -91,10 +91,15 @@ def get_version(fastani_exe: Path = pyani_config.FASTANI_DEFAULT) -> str:
     - no version info returned
     """
     try:
-        fastani_path = Path(shutil.which(fastani_exe))  # type:ignore
-    # Returns a TypeError if `fastani_exe` is None
+        # Returns a TypeError if `fastani_exe` is None
+        try:
+            fastani_path = shutil.which(fastani_exe)  # type:ignore
+        except TypeError:
+            return f"expected path to fastANI executable; received {fastani_exe}"
+        # Returns a TypeError if `fastani_path` is not on the PATH
+        fastani_path = Path(fastani_path)
     except TypeError:
-        return f"expected file location; received {fastani_exe}"
+        return f"{fastani_exe} is not found in $PATH"
 
     # If a string that is not an executable is passed to
     # shutil.which(), the return value will be None, so

--- a/pyani/fastani.py
+++ b/pyani/fastani.py
@@ -86,6 +86,7 @@ def get_version(fastani_exe: Path = pyani_config.FASTANI_DEFAULT) -> str:
 
     The following circumstances are explicitly reported as strings:
 
+    - a value of None given for the executable
     - no executable at passed path
     - non-executable file at passed path (this includes cases where the user doesn't have execute permissions on the file)
     - no version info returned

--- a/pyani/fastani.py
+++ b/pyani/fastani.py
@@ -92,9 +92,13 @@ def get_version(fastani_exe: Path = pyani_config.FASTANI_DEFAULT) -> str:
     """
     try:
         fastani_path = Path(shutil.which(fastani_exe))  # type:ignore
+    # Returns a TypeError if `fastani_exe` is None
     except TypeError:
-        return f"{fastani_exe} is not found in $PATH"
+        return f"expected file location; received {fastani_exe}"
 
+    # If a string that is not an executable is passed to
+    # shutil.which(), the return value will be None, so
+    # this check is still needed
     if fastani_path is None:
         return f"{fastani_exe} is not found in $PATH"
 

--- a/tests/test_fastani.py
+++ b/tests/test_fastani.py
@@ -93,7 +93,7 @@ def test_get_version_nonetype():
 
     assert (
         fastani.get_version(test_file_0)
-        == f"expected file location; received {test_file_0}"
+        == f"expected path to fastANI executable; received {test_file_0}"
     )
 
 

--- a/tests/test_fastani.py
+++ b/tests/test_fastani.py
@@ -97,14 +97,14 @@ def test_get_version_nonetype():
 # Test case 1: there is no executable
 def test_get_version_no_exe(executable_missing, monkeypatch):
     """Test behaviour when there is no file at the specified executable location."""
-    test_file_1 = Path("/non/existent/blastn")
+    test_file_1 = Path("/non/existent/fastani")
     assert fastani.get_version(test_file_1) == f"No fastANI executable at {test_file_1}"
 
 
 # Test case 2: there is a file, but it is not executable
 def test_get_version_exe_not_executable(executable_not_executable, monkeypatch):
     """Test behaviour when the file at the executable location is not executable."""
-    test_file_2 = Path("/non/executable/blastn")
+    test_file_2 = Path("/non/executable/fastani")
     assert (
         fastani.get_version(test_file_2)
         == f"fastANI exists at {test_file_2} but not executable"
@@ -114,7 +114,7 @@ def test_get_version_exe_not_executable(executable_not_executable, monkeypatch):
 # Test case 3: there is an executable file, but the version can't be retrieved
 def test_get_version_exe_no_version(executable_without_version, monkeypatch):
     """Test behaviour when the version for the executable can not be retrieved."""
-    test_file_3 = Path("/missing/version/blastn")
+    test_file_3 = Path("/missing/version/fastani")
     assert (
         fastani.get_version(test_file_3)
         == f"fastANI exists at {test_file_3} but could not retrieve version"

--- a/tests/test_fastani.py
+++ b/tests/test_fastani.py
@@ -91,33 +91,44 @@ def test_get_version_nonetype():
     """Test behaviour when no location for the executable is given."""
     test_file_0 = None
 
-    assert fastani.get_version(test_file_0) == f"{test_file_0} is not found in $PATH"
-
-
-# Test case 1: there is no executable
-def test_get_version_no_exe(executable_missing, monkeypatch):
-    """Test behaviour when there is no file at the specified executable location."""
-    test_file_1 = Path("/non/existent/fastani")
-    assert fastani.get_version(test_file_1) == f"No fastANI executable at {test_file_1}"
-
-
-# Test case 2: there is a file, but it is not executable
-def test_get_version_exe_not_executable(executable_not_executable, monkeypatch):
-    """Test behaviour when the file at the executable location is not executable."""
-    test_file_2 = Path("/non/executable/fastani")
     assert (
-        fastani.get_version(test_file_2)
-        == f"fastANI exists at {test_file_2} but not executable"
+        fastani.get_version(test_file_0)
+        == f"expected file location; received {test_file_0}"
     )
 
 
-# Test case 3: there is an executable file, but the version can't be retrieved
-def test_get_version_exe_no_version(executable_without_version, monkeypatch):
-    """Test behaviour when the version for the executable can not be retrieved."""
-    test_file_3 = Path("/missing/version/fastani")
+# Test case 1: no such file exists
+def test_get_version_random_string():
+    """Test behaviour when the given 'file' is not one."""
+    test_file_1 = "string"
+
+    assert fastani.get_version(test_file_1) == f"{test_file_1} is not found in $PATH"
+
+
+# Test case 2: there is no executable
+def test_get_version_no_exe(executable_missing, monkeypatch):
+    """Test behaviour when there is no file at the specified executable location."""
+    test_file_2 = Path("/non/existent/fastani")
+    assert fastani.get_version(test_file_2) == f"No fastANI executable at {test_file_2}"
+
+
+# Test case 3: there is a file, but it is not executable
+def test_get_version_exe_not_executable(executable_not_executable, monkeypatch):
+    """Test behaviour when the file at the executable location is not executable."""
+    test_file_3 = Path("/non/executable/fastani")
     assert (
         fastani.get_version(test_file_3)
-        == f"fastANI exists at {test_file_3} but could not retrieve version"
+        == f"fastANI exists at {test_file_3} but not executable"
+    )
+
+
+# Test case 4: there is an executable file, but the version can't be retrieved
+def test_get_version_exe_no_version(executable_without_version, monkeypatch):
+    """Test behaviour when the version for the executable can not be retrieved."""
+    test_file_4 = Path("/missing/version/fastani")
+    assert (
+        fastani.get_version(test_file_4)
+        == f"fastANI exists at {test_file_4} but could not retrieve version"
     )
 
 

--- a/tests/test_subcmd_09_fastani.py
+++ b/tests/test_subcmd_09_fastani.py
@@ -52,7 +52,7 @@ class TestfastANISubcommand(unittest.TestCase):
         self.scheduler = "multiprocessing"
 
         # Null logger instance
-        self.logger = logging.getLogger("TestIndexSubcommand logger")
+        self.logger = logging.getLogger("TestfastANISubcommand logger")
         self.logger.addHandler(logging.NullHandler())
 
         # Command line namespaces


### PR DESCRIPTION
Addition of a new test case to address some previously uncovered code.

Closes #405.

## Type of change

 (not quite a bug fix, really, but this is the closest option)

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md`)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed
  - [x] new code is commented, especially in hard-to-understand areas
  - [x] corresponding changes to documentation have been made
  - [x] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with `flake8` and `black` before submission
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [ ] Request a code review
- [ ] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani/pulls) in the `pyani` repository
