### PR TITLE
Passing a string to pd.read_json is deprecated

### DIFF
--- a/pyani/pyani_classify.py
+++ b/pyani/pyani_classify.py
@@ -40,6 +40,7 @@
 """Module providing functions to generate clusters/species hypotheses."""
 
 from typing import Dict, List, NamedTuple, Tuple
+from io import StringIO
 
 import networkx as nx  # type: ignore
 import pandas as pd  # type: ignore
@@ -75,8 +76,12 @@ def build_graph_from_results(
     :param id_min:      - minimum identity for an edge
     """
     # Parse identity and coverage matrices
-    mat_identity = label_results_matrix(pd.read_json(results.df_identity), label_dict)
-    mat_coverage = label_results_matrix(pd.read_json(results.df_coverage), label_dict)
+    mat_identity = label_results_matrix(
+        pd.read_json(StringIO(results.df_identity)), label_dict
+    )
+    mat_coverage = label_results_matrix(
+        pd.read_json(StringIO(results.df_coverage)), label_dict
+    )
 
     node_names = mat_coverage.columns
     rows = []


### PR DESCRIPTION
See also #425 for ``subcmd_plot.py`` and #437 for ``pyani/scripts/subcommands/subcmd_report.py``

Spotted in the CI logs for macOS - an easy deprecation to fix, but not the only one.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [x] Fork the `pyani` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md`)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed
  - [ ] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [ ] Test locally with `pytest -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with `flake8` and `black` before submission
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani/pulls) in the `pyani` repository
