### PR TITLE
Fix error message for missing <inputdir>/<genome>.md5 file

### DIFF
--- a/pyani/pyani_files.py
+++ b/pyani/pyani_files.py
@@ -109,7 +109,7 @@ def get_fasta_and_hash_paths(dirname: Path = Path(".")) -> List[Tuple[Path, Path
             hashfile = infile.with_suffix(".md5")
             logger.warning(f"... trying {hashfile}.")
         if not hashfile.is_file():
-            raise PyaniFilesException("Alternate hashfile {hashfile} does not exist.")
+            raise PyaniFilesException(f"Alternate hashfile {hashfile} does not exist.")
         outfiles.append((infile, hashfile))
     return outfiles
 


### PR DESCRIPTION
Fix error message for missing ``<inputdir>/<genome>.md5`` file.

In this case triggered by running ``pyani createdb`` and then ``pyani anim`` without indexing the FASTA files.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [x] Fork the `pyani` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md`)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed
  - [ ] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [ ] Test locally with `pytest -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with `flake8` and `black` before submission
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani/pulls) in the `pyani` repository
